### PR TITLE
Remove old updater since it doesn't work anymore & small fixes

### DIFF
--- a/src/Components/Modules/Console.cpp
+++ b/src/Components/Modules/Console.cpp
@@ -593,7 +593,7 @@ namespace Components
 				Utils::Hook(0x43D570, Console::StdOutError, HOOK_JUMP).install()->quick();
 			}
 		}
-		else if (!Dedicated::IsEnabled() || ZoneBuilder::IsEnabled()) // ZoneBuilder uses the game's console, until the native one is adapted.
+		else if (Flags::HasFlag("console") || ZoneBuilder::IsEnabled()) // ZoneBuilder uses the game's console, until the native one is adapted.
 		{
 			Utils::Hook::Nop(0x60BB58, 11);
 

--- a/src/Components/Modules/Console.cpp
+++ b/src/Components/Modules/Console.cpp
@@ -593,7 +593,7 @@ namespace Components
 				Utils::Hook(0x43D570, Console::StdOutError, HOOK_JUMP).install()->quick();
 			}
 		}
-		else if (Flags::HasFlag("console") || ZoneBuilder::IsEnabled()) // ZoneBuilder uses the game's console, until the native one is adapted.
+		else if (!Dedicated::IsEnabled() || ZoneBuilder::IsEnabled()) // ZoneBuilder uses the game's console, until the native one is adapted.
 		{
 			Utils::Hook::Nop(0x60BB58, 11);
 

--- a/src/Components/Modules/Maps.cpp
+++ b/src/Components/Modules/Maps.cpp
@@ -762,8 +762,7 @@ namespace Components
 				{
 					if (pack.index == dlc)
 					{
-						News::LaunchUpdater(Utils::String::VA("-dlc %i -c", pack.index));
-						//ShellExecuteA(nullptr, "open", pack.url.data(), nullptr, nullptr, SW_SHOWNORMAL);
+						ShellExecute(0, 0, L"https://iw4x.org/downloads.html", 0, 0, SW_SHOW);
 						return;
 					}
 				}

--- a/src/Components/Modules/News.cpp
+++ b/src/Components/Modules/News.cpp
@@ -6,9 +6,6 @@ namespace Components
 {
 	bool News::Terminate;
 	std::thread News::Thread;
-	std::string News::UpdaterArgs;
-	std::string News::UpdaterHash;
-	std::mutex News::UpdaterMutex;
 
 	bool News::unitTest()
 	{
@@ -33,165 +30,18 @@ namespace Components
 		return result;
 	}
 
-	void News::ExitProcessStub(unsigned int exitCode)
-	{
-		std::this_thread::sleep_for(10ms);
-
-		STARTUPINFOA        sInfo;
-		PROCESS_INFORMATION pInfo;
-
-		ZeroMemory(&sInfo, sizeof(sInfo));
-		ZeroMemory(&pInfo, sizeof(pInfo));
-		sInfo.cb = sizeof(sInfo);
-
-		CreateProcessA("updater.exe", const_cast<char*>(Utils::String::VA("updater.exe %s", News::UpdaterArgs.data())), nullptr, nullptr, false, NULL, nullptr, nullptr, &sInfo, &pInfo);
-
-		if (pInfo.hThread && pInfo.hThread != INVALID_HANDLE_VALUE) CloseHandle(pInfo.hThread);
-		if (pInfo.hProcess && pInfo.hProcess != INVALID_HANDLE_VALUE) CloseHandle(pInfo.hProcess);
-
-		TerminateProcess(GetCurrentProcess(), exitCode);
-	}
-
-	bool News::GetLatestUpdater()
-	{
-		std::lock_guard<std::mutex> _(News::UpdaterMutex);
-
-		if (Utils::IO::FileExists("updater.exe"))
-		{
-			// Generate hash of local updater.exe
-			std::string localUpdater = Utils::IO::ReadFile("updater.exe");
-			localUpdater = Utils::Cryptography::SHA1::Compute(localUpdater, true);
-
-			static Utils::Time::Interval updateInterval;
-			if (News::UpdaterHash.empty() || updateInterval.elapsed(15min)) // Check for updater Update every 15 mins max
-			{
-				updateInterval.update();
-
-				std::string data = Utils::Cache::GetFile("/json/updater"); // {"updater.exe":{"SHA1":"*HASH*"}}
-
-				std::string error;
-				json11::Json listData = json11::Json::parse(data, error);
-
-				if (error.empty() || listData.is_object())
-				{
-					News::UpdaterHash = listData["updater.exe"]["SHA1"].string_value();
-				}
-			}
-
-			if (!News::UpdaterHash.empty() && localUpdater != News::UpdaterHash)
-			{
-				remove("updater.exe");
-			}
-		}
-
-		if (!Utils::IO::FileExists("updater.exe"))
-		{
-			return News::DownloadUpdater();
-		}
-
-		return true;
-	}
-
-	bool News::DownloadUpdater()
-	{
-		std::string data = Utils::Cache::GetFile("/iw4/updater.exe");
-
-		if (!data.empty())
-		{
-			Utils::IO::WriteFile("updater.exe", data);
-			return true;
-		}
-
-		return false;
-	}
-
 	const char* News::GetNewsText()
 	{
 		return Localization::Get("MPUI_MOTD_TEXT");
 	}
 
-	void News::CheckForUpdate()
-	{
-		std::string _client = Utils::Cache::GetFile("/json/client");
-
-		if (!_client.empty())
-		{
-			std::string error;
-			json11::Json client = json11::Json::parse(_client.data(), error);
-
-			int revisionNumber;
-
-			if (client["revision"].is_number())
-			{
-				revisionNumber = client["revision"].int_value();
-			}
-			else if (client["revision"].is_string())
-			{
-				revisionNumber = atoi(client["revision"].string_value().data());
-			}
-			else return;
-
-			Dvar::Var("cl_updateversion").get<Game::dvar_t*>()->current.integer = revisionNumber;
-			Dvar::Var("cl_updateavailable").get<Game::dvar_t*>()->current.enabled = (revisionNumber > REVISION);
-
-			// if there is an update then show the toast, but only once
-			static bool showToast = true;
-			if (revisionNumber > REVISION && showToast)
-			{
-				showToast = false;
-				Scheduler::OnReady([]()
-				{
-					Toast::Show("cardicon_gears", "^4Update Available", "There is an update available for your client!", 5000);
-				});
-			}
-		}
-	}
-
-	void News::LaunchUpdater(const std::string& params)
-	{
-		if (News::Updating()) return;
-
-		News::UpdaterArgs = params;
-
-		Localization::SetTemp("MENU_RECONNECTING_TO_PARTY", "Downloading updater");
-		Command::Execute("openmenu popup_reconnectingtoparty", true);
-
-		// Run the updater on shutdown
-		Utils::Hook::Set(0x6D72A0, News::ExitProcessStub);
-
-		std::thread([]()
-		{
-			if (News::GetLatestUpdater())
-			{
-				Console::SetSkipShutdown();
-				Command::Execute("wait 300; quit;", false);
-			}
-			else
-			{
-				Localization::ClearTemp();
-				News::UpdaterArgs.clear();
-				Command::Execute("closemenu popup_reconnectingtoparty", false);
-				Game::ShowMessageBox("Failed to download the updater!", "Error");
-			}
-		}).detach();
-	}
-
-	bool News::Updating()
-	{
-		return !News::UpdaterArgs.empty();
-	}
-
 	News::News()
 	{
-		News::UpdaterArgs.clear();
-		News::UpdaterHash.clear();
 		if (ZoneBuilder::IsEnabled() || Dedicated::IsEnabled()) return; // Maybe also dedi?
 
 		Dvar::Register<bool>("g_firstLaunch", true, Game::DVAR_FLAG_SAVED, "");
 
 		Dvar::Register<int>("cl_updateoldversion", REVISION, REVISION, REVISION, Game::DVAR_FLAG_WRITEPROTECTED, "Current version number.");
-		Dvar::Register<int>("cl_updateversion", 0, 0, -1, Game::DVAR_FLAG_WRITEPROTECTED, "New version number.");
-		Dvar::Register<bool>("cl_updateavailable", false, Game::DVAR_FLAG_WRITEPROTECTED, "New update is available.");
 
 		UIScript::Add("checkFirstLaunch", [](UIScript::Token)
 		{
@@ -221,25 +71,12 @@ namespace Components
 		Localization::Set("MPUI_CHANGELOG_TEXT", "Loading...");
 		Localization::Set("MPUI_MOTD_TEXT", NEWS_MOTD_DEFAULT);
 
-		//News::GetLatestUpdater();
-
 		// make newsfeed (ticker) menu items not cut off based on safe area
 		Utils::Hook::Nop(0x63892D, 5);
 
 		// hook for getting the news ticker string
 		Utils::Hook::Nop(0x6388BB, 2); // skip the "if (item->text[0] == '@')" localize check
 		Utils::Hook(0x6388C1, News::GetNewsText, HOOK_CALL).install()->quick();
-
-		Command::Add("checkforupdate", [](Command::Params*)
-		{
-			News::CheckForUpdate();
-		});
-
-		Command::Add("getautoupdate", [](Command::Params*)
-		{
-			if (!Dvar::Var("cl_updateavailable").get<Game::dvar_t*>()->current.enabled) return;
-			News::LaunchUpdater("-update -c");
-		});
 
 		if (!Utils::IsWineEnvironment() && !Loader::IsPerformingUnitTests())
 		{
@@ -257,12 +94,8 @@ namespace Components
 
 				if (!Loader::IsPerformingUnitTests() && !News::Terminate)
 				{
-					News::GetLatestUpdater();
-
 					while (!News::Terminate)
 					{
-						News::CheckForUpdate();
-
 						// Sleep for 3 minutes
 						for (int i = 0; i < 180 && !News::Terminate; ++i)
 						{
@@ -272,12 +105,6 @@ namespace Components
 				}
 			});
 		}
-	}
-
-	News::~News()
-	{
-		News::UpdaterArgs.clear();
-		News::UpdaterHash.clear();
 	}
 
 	void News::preDestroy()

--- a/src/Components/Modules/News.hpp
+++ b/src/Components/Modules/News.hpp
@@ -6,26 +6,15 @@ namespace Components
 	{
 	public:
 		News();
-		~News();
 
 		void preDestroy() override;
 		bool unitTest() override;
 
-		static void LaunchUpdater(const std::string& params);
-		static bool Updating();
-
 	private:
-		static std::string UpdaterArgs;
-		static std::string UpdaterHash;
 		static std::thread Thread;
-		static std::mutex UpdaterMutex;
 
 		static bool Terminate;
-		static bool GetLatestUpdater();
 		static bool DownloadUpdater();
-
-		static void CheckForUpdate();
-		static void ExitProcessStub(unsigned int exitCode);
 
 		static const char* GetNewsText();
 	};


### PR DESCRIPTION
- Remove code that downloads the deprecated updater
- Open iw4x.org/downloads (which holds a download link to all dlcs) when clicking on a map pack in the store instead of using the deprecated updater
- Start external console by default on the client, this can help people solve issues when their game does not restore the window during a vid_restart (happens alot)