### PR TITLE
[QuickPatch] Fix crash in G_GetClientScore

### DIFF
--- a/src/Components/Modules/QuickPatch.hpp
+++ b/src/Components/Modules/QuickPatch.hpp
@@ -19,7 +19,7 @@ namespace Components
 		static void SelectStringTableEntryInDvarStub();
 
 		static int SVCanReplaceServerCommand(Game::client_t *client, const char *cmd);
-		static int SVGameClientNum();
+		static int G_GetClientScore();
 
 		static int MsgReadBitsCompressCheckSV(const char *from, char *to, int size);
 		static int MsgReadBitsCompressCheckCL(const char *from, char *to, int size);


### PR DESCRIPTION
fixes #43 

Fixed exception in G_GetClientScore that would happen when the function was called before the game was initialised, such as by IW4x's http server endpoint /info