### PR TITLE
disable steam for now + add custom title menu

### DIFF
--- a/src/Components/Modules/Menus.cpp
+++ b/src/Components/Modules/Menus.cpp
@@ -907,6 +907,7 @@ namespace Components
 			Menus::Add("ui_mp/pc_store.menu");
 			Menus::Add("ui_mp/iw4x_credits.menu");
 			Menus::Add("ui_mp/resetclass.menu");
+			Menus::Add("ui_mp/popup_customtitle.menu");
 	}
 
 	Menus::~Menus()

--- a/src/Steam/Steam.cpp
+++ b/src/Steam/Steam.cpp
@@ -111,7 +111,7 @@ namespace Steam
 	{
 		bool SteamAPI_Init()
 		{
-			Proxy::SetGame(10190);
+			/*Proxy::SetGame(10190);
 
 			if (!Proxy::Inititalize())
 			{
@@ -122,7 +122,7 @@ namespace Steam
 			{
 				Proxy::SetMod("IW4x: Modern Warfare 2");
 				Proxy::RunGame();
-			}
+			}*/
 
 			return true;
 		}

--- a/src/Steam/Steam.cpp
+++ b/src/Steam/Steam.cpp
@@ -111,6 +111,7 @@ namespace Steam
 	{
 		bool SteamAPI_Init()
 		{
+			//The latest steam update has broke IW4x's steam integration. As of now the best way of dealing with this is to just disable it. This has been commented out so that if fixed, this may be easily enabled once again.
 			/*Proxy::SetGame(10190);
 
 			if (!Proxy::Inititalize())


### PR DESCRIPTION
The latest steam update has broke IW4x's steam integration. As of now the best way of dealing with this is to just disable it. The code has been commented out so that in the future if fixed, this may easily be enabled once again.