### PR TITLE
Adds printing script runtime errors when in developer

### DIFF
--- a/src/Components/Modules/Script.cpp
+++ b/src/Components/Modules/Script.cpp
@@ -283,10 +283,10 @@ namespace Components
 			call Script::GetFunction
 			add esp, 0Ch
 
-			returnSafe:
+		returnSafe:
 			pop edi
-				pop esi
-				retn
+			pop esi
+			retn
 		}
 	}
 
@@ -417,121 +417,121 @@ namespace Components
 	{
 		// System time
 		Script::AddFunction("GetSystemTime", [](Game::scr_entref_t) // gsc: GetSystemTime()
-			{
-				SYSTEMTIME time;
-				GetSystemTime(&time);
+		{
+			SYSTEMTIME time;
+			GetSystemTime(&time);
 
-				Game::Scr_AddInt(time.wSecond);
-			});
+			Game::Scr_AddInt(time.wSecond);
+		});
 
 		Script::AddFunction("GetSystemMilliseconds", [](Game::scr_entref_t) // gsc: GetSystemMilliseconds()
-			{
-				SYSTEMTIME time;
-				GetSystemTime(&time);
+		{
+			SYSTEMTIME time;
+			GetSystemTime(&time);
 
-				Game::Scr_AddInt(time.wMilliseconds);
-			});
+			Game::Scr_AddInt(time.wMilliseconds);
+		});
 
 		// Print to console, even without being in 'developer 1'.
 		Script::AddFunction("PrintConsole", [](Game::scr_entref_t) // gsc: PrintConsole(<string>)
+		{
+			if (Game::Scr_GetNumParam() != 1 || Game::Scr_GetType(0) != Game::VAR_STRING)
 			{
-				if (Game::Scr_GetNumParam() != 1 || Game::Scr_GetType(0) != Game::VAR_STRING)
-				{
-					Game::Scr_Error("^1PrintConsole: Needs one string parameter!\n");
-					return;
-				}
+				Game::Scr_Error("^1PrintConsole: Needs one string parameter!\n");
+				return;
+			}
 
-				auto str = Game::Scr_GetString(0);
+			auto str = Game::Scr_GetString(0);
 
-				Game::Com_Printf(0, str);
-			});
+			Game::Com_Printf(0, str);
+		});
 
 		// Executes command to the console
 		Script::AddFunction("Exec", [](Game::scr_entref_t) // gsc: Exec(<string>)
+		{
+			if (Game::Scr_GetNumParam() != 1 || Game::Scr_GetType(0) != Game::VAR_STRING)
 			{
-				if (Game::Scr_GetNumParam() != 1 || Game::Scr_GetType(0) != Game::VAR_STRING)
-				{
-					Game::Scr_Error("^1Exec: Needs one string parameter!\n");
-					return;
-				}
+				Game::Scr_Error("^1Exec: Needs one string parameter!\n");
+				return;
+			}
 
-				auto str = Game::Scr_GetString(0);
+			auto str = Game::Scr_GetString(0);
 
-				Command::Execute(str, false);
-			});
+			Command::Execute(str, false);
+		});
 
 
 		// Script Storage Funcs
 		Script::AddFunction("StorageSet", [](Game::scr_entref_t) // gsc: StorageSet(<str key>, <str data>);
+		{
+			if (Game::Scr_GetNumParam() != 2 || Game::Scr_GetType(0) != Game::VAR_STRING || Game::Scr_GetType(1) != Game::VAR_STRING)
 			{
-				if (Game::Scr_GetNumParam() != 2 || Game::Scr_GetType(0) != Game::VAR_STRING || Game::Scr_GetType(1) != Game::VAR_STRING)
-				{
-					Game::Scr_Error("^1StorageSet: Needs two string parameters!\n");
-					return;
-				}
+				Game::Scr_Error("^1StorageSet: Needs two string parameters!\n");
+				return;
+			}
 
-				std::string key = Game::Scr_GetString(0);
-				std::string data = Game::Scr_GetString(1);
+			std::string key = Game::Scr_GetString(0);
+			std::string data = Game::Scr_GetString(1);
 
-				Script::ScriptStorage.insert_or_assign(key, data);
-			});
+			Script::ScriptStorage.insert_or_assign(key, data);
+		});
 
 		Script::AddFunction("StorageRemove", [](Game::scr_entref_t) // gsc: StorageRemove(<str key>);
+		{
+			if (Game::Scr_GetNumParam() != 1 || Game::Scr_GetType(0) != Game::VAR_STRING)
 			{
-				if (Game::Scr_GetNumParam() != 1 || Game::Scr_GetType(0) != Game::VAR_STRING)
-				{
-					Game::Scr_Error("^1StorageRemove: Needs one string parameter!\n");
-					return;
-				}
+				Game::Scr_Error("^1StorageRemove: Needs one string parameter!\n");
+				return;
+			}
 
-				std::string key = Game::Scr_GetString(0);
+			std::string key = Game::Scr_GetString(0);
 
-				if (!Script::ScriptStorage.contains(key))
-				{
-					Game::Scr_Error(Utils::String::VA("^1StorageRemove: Store does not have key '%s'!\n", key.c_str()));
-					return;
-				}
+			if (!Script::ScriptStorage.contains(key))
+			{
+				Game::Scr_Error(Utils::String::VA("^1StorageRemove: Store does not have key '%s'!\n", key.c_str()));
+				return;
+			}
 
-				Script::ScriptStorage.erase(key);
-			});
+			Script::ScriptStorage.erase(key);
+		});
 
 		Script::AddFunction("StorageGet", [](Game::scr_entref_t) // gsc: StorageGet(<str key>);
+		{
+			if (Game::Scr_GetNumParam() != 1 || Game::Scr_GetType(0) != Game::VAR_STRING)
 			{
-				if (Game::Scr_GetNumParam() != 1 || Game::Scr_GetType(0) != Game::VAR_STRING)
-				{
-					Game::Scr_Error("^1StorageGet: Needs one string parameter!\n");
-					return;
-				}
+				Game::Scr_Error("^1StorageGet: Needs one string parameter!\n");
+				return;
+			}
 
-				std::string key = Game::Scr_GetString(0);
+			std::string key = Game::Scr_GetString(0);
 
-				if (!Script::ScriptStorage.contains(key))
-				{
-					Game::Scr_Error(Utils::String::VA("^1StorageGet: Store does not have key '%s'!\n", key.c_str()));
-					return;
-				}
+			if (!Script::ScriptStorage.contains(key))
+			{
+				Game::Scr_Error(Utils::String::VA("^1StorageGet: Store does not have key '%s'!\n", key.c_str()));
+				return;
+			}
 
-				auto data = Script::ScriptStorage.at(key);
-				Game::Scr_AddString(data.c_str());
-			});
+			auto data = Script::ScriptStorage.at(key);
+			Game::Scr_AddString(data.c_str());
+		});
 
 		Script::AddFunction("StorageHas", [](Game::scr_entref_t) // gsc: StorageHas(<str key>);
+		{
+			if (Game::Scr_GetNumParam() != 1 || Game::Scr_GetType(0) != Game::VAR_STRING)
 			{
-				if (Game::Scr_GetNumParam() != 1 || Game::Scr_GetType(0) != Game::VAR_STRING)
-				{
-					Game::Scr_Error("^1StorageHas: Needs one string parameter!\n");
-					return;
-				}
+				Game::Scr_Error("^1StorageHas: Needs one string parameter!\n");
+				return;
+			}
 
-				std::string key = Game::Scr_GetString(0);
+			std::string key = Game::Scr_GetString(0);
 
-				Game::Scr_AddInt(Script::ScriptStorage.contains(key));
-			});
+			Game::Scr_AddInt(Script::ScriptStorage.contains(key));
+		});
 
 		Script::AddFunction("StorageClear", [](Game::scr_entref_t) // gsc: StorageClear();
-			{
-				Script::ScriptStorage.clear();
-			});
+		{
+			Script::ScriptStorage.clear();
+		});
 	}
 
 	Script::Script()
@@ -544,12 +544,12 @@ namespace Components
 
 		// enable scr_error printing if in developer
 		Dvar::OnInit([]()
-			{
-				int developer = Dvar::Var("developer").get<int>();
+		{
+			int developer = Dvar::Var("developer").get<int>();
 
-				if (developer > 0)
-					Utils::Hook::Set<BYTE>(0x48D8C7, 0x75);
-			});
+			if (developer > 0)
+				Utils::Hook::Set<BYTE>(0x48D8C7, 0x75);
+		});
 
 		Utils::Hook(0x612E8D, Script::FunctionError, HOOK_CALL).install()->quick();
 		Utils::Hook(0x612EA2, Script::FunctionError, HOOK_CALL).install()->quick();
@@ -567,9 +567,9 @@ namespace Components
 		Utils::Hook(0x4D06BA, Script::ScrShutdownSystemStub, HOOK_CALL).install()->quick();
 
 		Script::AddFunction("debugBox", [](Game::scr_entref_t)
-			{
-				MessageBoxA(nullptr, Game::Scr_GetString(0), "DEBUG", 0);
-			}, true);
+		{
+			MessageBoxA(nullptr, Game::Scr_GetString(0), "DEBUG", 0);
+		}, true);
 
 		Script::AddFunctions();
 

--- a/src/Components/Modules/Script.hpp
+++ b/src/Components/Modules/Script.hpp
@@ -39,6 +39,7 @@ namespace Components
 		static std::vector<std::string> ScriptNameStack;
 		static unsigned short FunctionName;
 		static std::unordered_map<std::string, std::string> ScriptStorage;
+		static std::unordered_map<int, std::string> Script::ScriptBaseProgramNum;
 
 		static Utils::Signal<Scheduler::Callback> VMShutdownSignal;
 
@@ -61,6 +62,10 @@ namespace Components
 		static void GetFunctionStub();
 
 		static void ScrShutdownSystemStub(int);
+		static void StoreScriptBaseProgramNumStub();
+		static void StoreScriptBaseProgramNum();
+		static void Scr_PrintPrevCodePosStub();
+		static void Scr_PrintPrevCodePos(int);
 
 		static int SetExpFogStub();
 


### PR DESCRIPTION
When developer dvar is > 0  a user will see script runtime errors and the source gsc file of the error.

![image](https://user-images.githubusercontent.com/751729/102000441-18eb1380-3cad-11eb-9aca-3cea2be8fb28.png)
