### PR TITLE
Register the GSC HTTP functions reguardless of being in Dedicated to prevent Script Compile Error

### DIFF
--- a/src/Components/Modules/Script.hpp
+++ b/src/Components/Modules/Script.hpp
@@ -39,7 +39,7 @@ namespace Components
 		static std::vector<std::string> ScriptNameStack;
 		static unsigned short FunctionName;
 		static std::unordered_map<std::string, std::string> ScriptStorage;
-		static std::unordered_map<int, std::string> Script::ScriptBaseProgramNum;
+		static std::unordered_map<int, std::string> ScriptBaseProgramNum;
 
 		static Utils::Signal<Scheduler::Callback> VMShutdownSignal;
 


### PR DESCRIPTION
The HTTP GSC is only executable if -scriptablehttp or -dedicated flags are enabled. This is just so it prevents GSC code from not being compilable when the flags are not present. 