### PR TITLE
Do not interrupt gameplay for GSC errors

### DIFF
--- a/src/Components/Modules/Script.cpp
+++ b/src/Components/Modules/Script.cpp
@@ -548,7 +548,7 @@ namespace Components
 		{
 			int developer = Dvar::Var("developer").get<int>();
 
-			if (developer > 0)
+			if (developer > 0 && Dedicated::IsEnabled())
 				Utils::Hook::Set<BYTE>(0x48D8C7, 0x75);
 		});
 


### PR DESCRIPTION
Make iw4x developers life easier by not freezing their game up for GSC errors in basegame GSCs 🗡️ 
I understand why this feature exists, but it makes developing for iw4x impossible unless you comment it out - so maybe it doesn't belong on graphical clients.