### PR TITLE
Use new URL for Wiki

### DIFF
--- a/src/Components/Modules/News.cpp
+++ b/src/Components/Modules/News.cpp
@@ -60,7 +60,7 @@ namespace Components
 		UIScript::Add("visitWiki", [](UIScript::Token)
 		{
 			//Utils::OpenUrl(Utils::Cache::GetStaticUrl("/wiki/"));
-			Utils::OpenUrl("https://github.com/Jawesome99/IW4x/wiki");
+			Utils::OpenUrl("https://github.com/Emosewaj/IW4x/wiki");
 		});
 
 		UIScript::Add("visitDiscord", [](UIScript::Token)


### PR DESCRIPTION
I've changed usernames from Jawesome99 to Emosewaj a while ago, relying on GitHub to keep the redirect up forever isn't a smart idea.