### PR TITLE
Fix rcon not working properly on party servers

### DIFF
--- a/src/Components/Modules/Network.cpp
+++ b/src/Components/Modules/Network.cpp
@@ -121,7 +121,7 @@ namespace Components
 	}
 	bool Network::Address::isValid()
 	{
-		return (this->getType() != Game::netadrtype_t::NA_BAD && this->getType() >= Game::netadrtype_t::NA_BOT && this->getType() <= Game::netadrtype_t::NA_IP);
+		return (this->getType() != Game::netadrtype_t::NA_BAD && this->getType() >= Game::netadrtype_t::NA_BOT && this->getType() <= Game::netadrtype_t::NA_IP && this->address.ip.full != 0);
 	}
 	void Network::Handle(const std::string& packet, Utils::Slot<Network::Callback> callback)
 	{

--- a/src/Components/Modules/RCon.cpp
+++ b/src/Components/Modules/RCon.cpp
@@ -25,9 +25,13 @@ namespace Components
 			}
 			else
 			{
-				if (!RCon::Password.empty() && *reinterpret_cast<int*>(0xB2C540) >= 5) // Get our state
+				auto addr = reinterpret_cast<Game::netadr_t*>(0xA5EA44);
+				if (!RCon::Password.empty()) 
 				{
-					Network::Address target(reinterpret_cast<Game::netadr_t*>(0xA5EA44));
+					Network::Address target(addr);
+					if (!target.isValid()) {
+						target = Party::Target();
+					}
 
 					if (target.isValid())
 					{
@@ -107,9 +111,7 @@ namespace Components
 				static std::string outputBuffer;
 				outputBuffer.clear();
 
-#ifdef DEBUG
 				Logger::Print("Executing RCon request from %s: %s\n", address.getCString(), command.data());
-#endif
 
 				Logger::PipeOutput([](const std::string& output)
 				{

--- a/src/Components/Modules/RCon.cpp
+++ b/src/Components/Modules/RCon.cpp
@@ -29,7 +29,8 @@ namespace Components
 				if (!RCon::Password.empty()) 
 				{
 					Network::Address target(addr);
-					if (!target.isValid()) {
+					if (!target.isValid()) 
+					{
 						target = Party::Target();
 					}
 
@@ -75,6 +76,7 @@ namespace Components
 		Dvar::OnInit([]()
 		{
 			Dvar::Register<const char*>("rcon_password", "", Game::dvar_flag::DVAR_FLAG_NONE, "The password for rcon");
+			Dvar::Register<bool>("log_rcon_requests", true, Game::dvar_flag::DVAR_FLAG_NONE, "Print remote commands in the output log");
 		});
 
 		Network::Handle("rcon", [](Network::Address address, const std::string& _data)
@@ -111,7 +113,12 @@ namespace Components
 				static std::string outputBuffer;
 				outputBuffer.clear();
 
-				Logger::Print("Executing RCon request from %s: %s\n", address.getCString(), command.data());
+#ifndef DEBUG
+				if (Dvar::Var("log_rcon_requests").get<bool>())
+#endif
+				{
+					Logger::Print("Executing RCon request from %s: %s\n", address.getCString(), command.data());
+				}
 
 				Logger::PipeOutput([](const std::string& output)
 				{

--- a/src/Components/Modules/RCon.cpp
+++ b/src/Components/Modules/RCon.cpp
@@ -76,7 +76,7 @@ namespace Components
 		Dvar::OnInit([]()
 		{
 			Dvar::Register<const char*>("rcon_password", "", Game::dvar_flag::DVAR_FLAG_NONE, "The password for rcon");
-			Dvar::Register<bool>("log_rcon_requests", true, Game::dvar_flag::DVAR_FLAG_NONE, "Print remote commands in the output log");
+			Dvar::Register<bool>("log_rcon_requests", false, Game::dvar_flag::DVAR_FLAG_NONE, "Print remote commands in the output log");
 		});
 
 		Network::Handle("rcon", [](Network::Address address, const std::string& _data)


### PR DESCRIPTION
Might be better to use a switch that tells us if we're in a party or not, but Party::IsInLobby doesn't do it and the clientstate is `CS_FREE` even though we're connected and speaking - so this works, and works properly, I guess that's enough :D 