### PR TITLE
Skip specops entities

### DIFF
--- a/src/Components/Modules/QuickPatch.cpp
+++ b/src/Components/Modules/QuickPatch.cpp
@@ -396,58 +396,7 @@ namespace Components
 		return std::function < T >(reinterpret_cast<T*>(procAddr));
 	}
 
-	//int __cdecl G_ParseSpawnVars(Game::SpawnVar* spawnVar){
-	//	if (Zones::Version() >= VERSION_ALPHA2) {
-	//		bool shouldBeRemoved = false;
-
-
-	//		for (auto i = 0; i < spawnVar->numSpawnVars; i++)
-	//		{
-	//			char** kvPair = spawnVar->spawnVars[i];
-	//			auto key = kvPair[0];
-	//			auto val = kvPair[1];
-	//			
-	//			bool isSpecOps = strncmp(key, "script_specialops", 16) == 0;
-	//			bool isSpecOpsOnly = *val == 49; // 49 => Ascii "1"
-
-	//			if (isSpecOps && isSpecOpsOnly) {
-	//				shouldBeRemoved = true;
-	//				break;
-	//			}
-	//		}
-
-	//		if (shouldBeRemoved) {
-	//			for (auto i = 0; i < spawnVar->numSpawnVars; i++)
-	//			{
-	//				char** kvPair = spawnVar->spawnVars[i];
-	//				auto key = kvPair[0];
-	//				auto val = kvPair[1];
-
-	//				bool isClassName = strncmp(key, "classname", 9) == 0;
-
-	//				if (isClassName) {
-	//					val = "dyn_lmao";
-	//				}
-	//			}
-	//		} 
-
-	//		if (shouldBeRemoved) {
-	//			spawnVar->numSpawnVars = 0;
-	//			spawnVar->numSpawnVarChars = 0;
-	//			spawnVar->spawnVarsValid = false;
-
-	//			//Components::Logger::Print("G_SpawnString: Removed %s\n", spawnVar->spawnVarChars);
-	//		}
-	//	}
-	//	
-	//	return Utils::Hook::Call<int(Game::SpawnVar*)>(0x4B3410)(spawnVar);
-	//}
-
-	BOOL __cdecl IsDynClassname(char* a1) {
-		//if (Zones::Version() >= VERSION_ALPHA2) {
-			bool shouldBeRemoved = false;
-
-
+	bool QuickPatch::IsDynClassnameStub(char* a1) {
 			for (auto i = 0; i < Game::spawnVars->numSpawnVars; i++)
 			{
 				char** kvPair = Game::spawnVars->spawnVars[i];
@@ -462,14 +411,9 @@ namespace Components
 					return true; // This will prevent spawning hopefully;
 				}
 			}
-		//}
 
-		return Utils::Hook::Call<BOOL(char*)>(0x444810)(a1);
+		return Utils::Hook::Call<bool(char*)>(0x444810)(a1);
 	}
-
-	//void __cdecl G_SpawnItem(Game::gentity_s* a1, signed int a2) {
-
-	//}
 
 	QuickPatch::QuickPatch()
 	{
@@ -514,11 +458,7 @@ namespace Components
 				(0xC000007B /*0x0000000A*/, 0, nullptr, nullptr, OptionShutdownSystem, &response);
 		});
 
-		Utils::Hook(0x5FBD6E, IsDynClassname, HOOK_CALL).install()->quick();
-
-		//Utils::Hook(0x4D8845, G_ParseSpawnVars, HOOK_CALL).install()->quick();
-		//Utils::Hook(0x4D8880, G_ParseSpawnVars, HOOK_CALL).install()->quick();
-		//Utils::Hook(0x4D886A, G_ParseSpawnVars, HOOK_CALL).install()->quick();
+		Utils::Hook(0x5FBD6E, QuickPatch::IsDynClassnameStub, HOOK_CALL).install()->quick();
 
 		// bounce dvar
 		sv_enableBounces = Game::Dvar_RegisterBool("sv_enableBounces", false, Game::DVAR_FLAG_REPLICATED, "Enables bouncing on the server");

--- a/src/Components/Modules/QuickPatch.cpp
+++ b/src/Components/Modules/QuickPatch.cpp
@@ -390,20 +390,24 @@ namespace Components
 
 	bool QuickPatch::IsDynClassnameStub(char* a1) 
 	{
-		for (auto i = 0; i < Game::spawnVars->numSpawnVars; i++)
-		{
-			char** kvPair = Game::spawnVars->spawnVars[i];
-			auto key = kvPair[0];
-			auto val = kvPair[1];
+		auto version = Zones::GetEntitiesZoneVersion();
 
-			bool isSpecOps = strncmp(key, "script_specialops", 17) == 0;
-			bool isSpecOpsOnly = val[0] == '1' && val[1] == '\0';
-
-			if (isSpecOps && isSpecOpsOnly) 
+		if (version >= VERSION_LATEST_CODO) {
+			for (auto i = 0; i < Game::spawnVars->numSpawnVars; i++)
 			{
-				// This will prevent spawning of any entity that contains "script_specialops: '1'" 
-				// It removes extra hitboxes / meshes on 461+ CODO multiplayer maps
-				return true; 
+				char** kvPair = Game::spawnVars->spawnVars[i];
+				auto key = kvPair[0];
+				auto val = kvPair[1];
+
+				bool isSpecOps = strncmp(key, "script_specialops", 17) == 0;
+				bool isSpecOpsOnly = val[0] == '1' && val[1] == '\0';
+
+				if (isSpecOps && isSpecOpsOnly)
+				{
+					// This will prevent spawning of any entity that contains "script_specialops: '1'" 
+					// It removes extra hitboxes / meshes on 461+ CODO multiplayer maps
+					return true;
+				}
 			}
 		}
 

--- a/src/Components/Modules/QuickPatch.cpp
+++ b/src/Components/Modules/QuickPatch.cpp
@@ -407,7 +407,6 @@ namespace Components
 				bool isSpecOpsOnly = *val == 49; // 49 => Ascii "1"
 
 				if (isSpecOps && isSpecOpsOnly) {
-					Components::Logger::Print("Prevented spawning of entity: %s\n", Game::spawnVars->spawnVarChars);
 					return true; // This will prevent spawning hopefully;
 				}
 			}

--- a/src/Components/Modules/QuickPatch.cpp
+++ b/src/Components/Modules/QuickPatch.cpp
@@ -396,27 +396,80 @@ namespace Components
 		return std::function < T >(reinterpret_cast<T*>(procAddr));
 	}
 
-	int __cdecl G_ParseSpawnVars(Game::SpawnVar* spawnVar){
-		if (Zones::Version() >= VERSION_ALPHA2) {
-			for (auto i = 0; i < spawnVar->numSpawnVars; i++)
+	//int __cdecl G_ParseSpawnVars(Game::SpawnVar* spawnVar){
+	//	if (Zones::Version() >= VERSION_ALPHA2) {
+	//		bool shouldBeRemoved = false;
+
+
+	//		for (auto i = 0; i < spawnVar->numSpawnVars; i++)
+	//		{
+	//			char** kvPair = spawnVar->spawnVars[i];
+	//			auto key = kvPair[0];
+	//			auto val = kvPair[1];
+	//			
+	//			bool isSpecOps = strncmp(key, "script_specialops", 16) == 0;
+	//			bool isSpecOpsOnly = *val == 49; // 49 => Ascii "1"
+
+	//			if (isSpecOps && isSpecOpsOnly) {
+	//				shouldBeRemoved = true;
+	//				break;
+	//			}
+	//		}
+
+	//		if (shouldBeRemoved) {
+	//			for (auto i = 0; i < spawnVar->numSpawnVars; i++)
+	//			{
+	//				char** kvPair = spawnVar->spawnVars[i];
+	//				auto key = kvPair[0];
+	//				auto val = kvPair[1];
+
+	//				bool isClassName = strncmp(key, "classname", 9) == 0;
+
+	//				if (isClassName) {
+	//					val = "dyn_lmao";
+	//				}
+	//			}
+	//		} 
+
+	//		if (shouldBeRemoved) {
+	//			spawnVar->numSpawnVars = 0;
+	//			spawnVar->numSpawnVarChars = 0;
+	//			spawnVar->spawnVarsValid = false;
+
+	//			//Components::Logger::Print("G_SpawnString: Removed %s\n", spawnVar->spawnVarChars);
+	//		}
+	//	}
+	//	
+	//	return Utils::Hook::Call<int(Game::SpawnVar*)>(0x4B3410)(spawnVar);
+	//}
+
+	BOOL __cdecl IsDynClassname(char* a1) {
+		//if (Zones::Version() >= VERSION_ALPHA2) {
+			bool shouldBeRemoved = false;
+
+
+			for (auto i = 0; i < Game::spawnVars->numSpawnVars; i++)
 			{
-				char** kvPair = spawnVar->spawnVars[i];
+				char** kvPair = Game::spawnVars->spawnVars[i];
 				auto key = kvPair[0];
 				auto val = kvPair[1];
-				
+
 				bool isSpecOps = strncmp(key, "script_specialops", 16) == 0;
 				bool isSpecOpsOnly = *val == 49; // 49 => Ascii "1"
 
 				if (isSpecOps && isSpecOpsOnly) {
-					spawnVar->spawnVars[i] = nullptr;
+					Components::Logger::Print("Prevented spawning of entity: %s\n", Game::spawnVars->spawnVarChars);
+					return true; // This will prevent spawning hopefully;
 				}
 			}
-		}
+		//}
 
-		Components::Logger::Print("G_SpawnString: %s %d\n", spawnVar->spawnVarChars, spawnVar->numSpawnVarChars);
-		
-		return Utils::Hook::Call<int(Game::SpawnVar*)>(0x4B3410)(spawnVar);
+		return Utils::Hook::Call<BOOL(char*)>(0x444810)(a1);
 	}
+
+	//void __cdecl G_SpawnItem(Game::gentity_s* a1, signed int a2) {
+
+	//}
 
 	QuickPatch::QuickPatch()
 	{
@@ -461,9 +514,11 @@ namespace Components
 				(0xC000007B /*0x0000000A*/, 0, nullptr, nullptr, OptionShutdownSystem, &response);
 		});
 
-		Utils::Hook(0x4D8845, G_ParseSpawnVars, HOOK_CALL).install()->quick();
-		Utils::Hook(0x4D8880, G_ParseSpawnVars, HOOK_CALL).install()->quick();
-		Utils::Hook(0x4D886A, G_ParseSpawnVars, HOOK_CALL).install()->quick();
+		Utils::Hook(0x5FBD6E, IsDynClassname, HOOK_CALL).install()->quick();
+
+		//Utils::Hook(0x4D8845, G_ParseSpawnVars, HOOK_CALL).install()->quick();
+		//Utils::Hook(0x4D8880, G_ParseSpawnVars, HOOK_CALL).install()->quick();
+		//Utils::Hook(0x4D886A, G_ParseSpawnVars, HOOK_CALL).install()->quick();
 
 		// bounce dvar
 		sv_enableBounces = Game::Dvar_RegisterBool("sv_enableBounces", false, Game::DVAR_FLAG_REPLICATED, "Enables bouncing on the server");

--- a/src/Components/Modules/QuickPatch.hpp
+++ b/src/Components/Modules/QuickPatch.hpp
@@ -47,5 +47,6 @@ namespace Components
 		static void PlayerCollisionStub();
 		static Game::dvar_t* g_playerEjection;
 		static void PlayerEjectionStub();
+		static bool IsDynClassnameStub(char* a1);
 	};
 }

--- a/src/Components/Modules/Zones.cpp
+++ b/src/Components/Modules/Zones.cpp
@@ -4,6 +4,7 @@
 namespace Components
 {
 	int Zones::ZoneVersion;
+	int Zones::EntitiesVersion;
 
 	int Zones::FxEffectIndex;
 	char* Zones::FxEffectStrings[64];
@@ -2561,6 +2562,8 @@ namespace Components
 	
 	int Zones::LoadMapEnts(bool atStreamStart, Game::MapEnts* buffer, int size)
 	{
+		EntitiesVersion = Zones::Version();
+
 		if (Zones::Version() >= 446)
 		{
 			size /= 44;

--- a/src/Components/Modules/Zones.hpp
+++ b/src/Components/Modules/Zones.hpp
@@ -24,10 +24,13 @@ namespace Components
 
 		static int Version() { return Zones::ZoneVersion; };
 
+		static int GetEntitiesZoneVersion() { return Zones::EntitiesVersion; };
+
 	private:
 	
 		static int ZoneVersion;
-
+		static int EntitiesVersion;
+		
 		static int FxEffectIndex;
 		static char* FxEffectStrings[64];
 


### PR DESCRIPTION
CODO has additional specops entities that mw2 doesn't know how to manage, which adds weird hitboxes on some multiplayer maps. This code prevents them from loading... but i'm not really satisfied with it. It's not using Zones::Version, although it should, but for some reason the version is always late (it works on second load, but not on the first one), maybe this happens too soon in the loading process? Would be surprising 

would love to get some input on it. 