### PR TITLE
Unless explicitely defined, do not generate iw4x specific zones

### DIFF
--- a/src/Components/Modules/ZoneBuilder.cpp
+++ b/src/Components/Modules/ZoneBuilder.cpp
@@ -378,7 +378,7 @@ namespace Components
 
 		Game::XFileHeader header =
 		{
-#ifdef DEBUG
+#ifndef GENERATE_IW4X_SPECIFIC_ZONES
 			XFILE_MAGIC_UNSIGNED,
 #else
 			XFILE_HEADER_IW4X | (static_cast<unsigned __int64>(XFILE_VERSION_IW4X) << 32),
@@ -394,7 +394,7 @@ namespace Components
 
 		std::string zoneBuffer = this->buffer.toBuffer();
 
-#ifndef DEBUG
+#ifdef GENERATE_IW4X_SPECIFIC_ZONES
 		// Insert a random byte, this will destroy the whole alignment and result in a crash, if not handled
 		zoneBuffer.insert(zoneBuffer.begin(), static_cast<char>(Utils::Cryptography::Rand::GenerateInt()));
 


### PR DESCRIPTION
IW4x-specific zone serve no purpose anymore in an open source project, so ZB should not generate them by default. 
This will make cod4-ported maps readable by any existing zone manager/dumper.

A macro is still defined in case a developer wants to build a version of zonetool that can still write these formats.
Reading is unaffected and previously-built zones will still be readable with this modification

See https://github.com/XLabsProject/iw4x-rawfiles/pull/1 
