### PR TITLE
Removed hook inside com quit fs. 

### DIFF
--- a/src/Components/Modules/QuickPatch.cpp
+++ b/src/Components/Modules/QuickPatch.cpp
@@ -380,14 +380,6 @@ namespace Components
 		}
 	}
 
-	template <typename T> std::function < T > ImportFunction(const std::string& dll, const std::string& function)
-	{
-		auto dllHandle = GetModuleHandleA(&dll[0]);
-		auto procAddr = GetProcAddress(dllHandle, &function[0]);
-
-		return std::function < T >(reinterpret_cast<T*>(procAddr));
-	}
-
 	QuickPatch::QuickPatch()
 	{
 		QuickPatch::FrameTime = 0;

--- a/src/Components/Modules/ZoneBuilder.cpp
+++ b/src/Components/Modules/ZoneBuilder.cpp
@@ -844,7 +844,7 @@ namespace Components
 
 		Command::Add("quit", [](Command::Params*)
 		{
-			ZoneBuilder::Quit();
+			Game::Com_Quitf_t();
 		});
 
 		Command::Add("error", [](Command::Params*)
@@ -919,12 +919,6 @@ namespace Components
 
 		// ReSharper disable once CppUnreachableCode
 		return 0;
-	}
-
-	void ZoneBuilder::Quit()
-	{
-		//TerminateProcess(GetCurrentProcess(), 0);
-		ExitProcess(0);
 	}
 
 	void ZoneBuilder::HandleError(int level, const char* format, ...)
@@ -1087,9 +1081,6 @@ namespace Components
 
 			// set new entry point
 			Utils::Hook(0x4513DA, ZoneBuilder::EntryPoint, HOOK_JUMP).install()->quick();
-
-			// set quit handler
-			Utils::Hook(0x4D4000, ZoneBuilder::Quit, HOOK_JUMP).install()->quick();
 
 			// handle com_error calls
 			Utils::Hook(0x4B22D0, ZoneBuilder::HandleError, HOOK_JUMP).install()->quick();

--- a/src/Components/Modules/ZoneBuilder.hpp
+++ b/src/Components/Modules/ZoneBuilder.hpp
@@ -138,7 +138,6 @@ namespace Components
 		static std::string FindMaterialByTechnique(const std::string& name);
 
 		static int __stdcall EntryPoint(HINSTANCE /*hInstance*/, HINSTANCE /*hPrevInstance*/, LPSTR /*lpCmdLine*/, int /*nShowCmd*/);
-		static void Quit();
 		static void HandleError(int level, const char* format, ...);
 		static void SoftErrorAssetOverflow();
 

--- a/src/Game/Functions.cpp
+++ b/src/Game/Functions.cpp
@@ -65,6 +65,7 @@ namespace Game
 	Com_Parse_t Com_Parse = Com_Parse_t(0x474D60);
 	Com_MatchToken_t Com_MatchToken = Com_MatchToken_t(0x447130);
 	Com_SetSlowMotion_t Com_SetSlowMotion = Com_SetSlowMotion_t(0x446E20);
+	Com_Quitf_t Com_Quit_f = Com_Quitf_t(0x4D4000);
 
 	Con_DrawMiniConsole_t Con_DrawMiniConsole = Con_DrawMiniConsole_t(0x464F30);
 	Con_DrawSolidConsole_t Con_DrawSolidConsole = Con_DrawSolidConsole_t(0x5A5040);

--- a/src/Game/Functions.hpp
+++ b/src/Game/Functions.hpp
@@ -130,6 +130,9 @@ namespace Game
 	typedef void(__cdecl * Com_SetSlowMotion_t)(float start, float end, int duration);
 	extern Com_SetSlowMotion_t Com_SetSlowMotion;
 
+	typedef void(__cdecl * Com_Quitf_t)();
+	extern Com_Quitf_t Com_Quit_f;
+
 	typedef char* (__cdecl * Con_DrawMiniConsole_t)(int localClientNum, int xPos, int yPos, float alpha);
 	extern Con_DrawMiniConsole_t Con_DrawMiniConsole;
 


### PR DESCRIPTION
This will allow another hook to actually be called (was skipped before this commit) and sync fs shutdown.
Also removed unused function (another function replaces it #96 ).
Proper quit command added. It will call com quit f just like s1x.
