### PR TITLE
No need to use getter function inside class function

### DIFF
--- a/src/Utils/Library.cpp
+++ b/src/Utils/Library.cpp
@@ -58,7 +58,7 @@ namespace Utils
 	{
 		if (this->is_valid())
 		{
-			FreeLibrary(this->getModule());
+			FreeLibrary(this->_module);
 		}
 
 		this->_module = nullptr;


### PR DESCRIPTION
This commit does not change code functionality. It should bring more consistency to the file modified because the class member variable module is always accessed directly without using the getter function.