### PR TITLE
colorblind friendly team colors!

### DIFF
--- a/src/Components/Modules/AssetHandler.cpp
+++ b/src/Components/Modules/AssetHandler.cpp
@@ -286,7 +286,7 @@ namespace Components
 			push [esp + 2Ch]
 			push [esp + 2Ch]
 			call AssetHandler::IsAssetEligible
-			add esp, 08h
+			add esp, 8h
 
 			mov [esp + 20h], eax
 			popad
@@ -295,13 +295,13 @@ namespace Components
 			test al, al
 			jz doNotLoad
 
-			mov eax, [esp + 8]
+			mov eax, [esp + 8h]
 			sub esp, 14h
 			mov ecx, 5BB657h
 			jmp ecx
 
 		doNotLoad:
-			mov eax, [esp + 8]
+			mov eax, [esp + 8h]
 			retn
 		}
 	}

--- a/src/Components/Modules/Colors.cpp
+++ b/src/Components/Modules/Colors.cpp
@@ -4,8 +4,8 @@ namespace Components
 {
 	Dvar::Var Colors::NewColors;
 	Dvar::Var Colors::ColorBlind;
-	Dvar::Var Colors::ColorAlly;
-	Dvar::Var Colors::ColorEnemy;
+	Game::dvar_t* Colors::ColorAllyColorBlind;
+	Game::dvar_t* Colors::ColorEnemyColorBlind;
 
 	std::vector<DWORD> Colors::ColorTable;
 
@@ -223,29 +223,27 @@ namespace Components
 	}
 
 	// Patches team overhead normally
-	bool Colors::Dvar_GetUnpackedColorByName(const char* name, float* color)
+	bool Colors::Dvar_GetUnpackedColorByName(const char* name, float* expandedColor)
 	{
 		if (Colors::ColorBlind.get<bool>())
 		{
-			auto str = std::string(name);
-			if (!str.compare("g_TeamColor_EnemyTeam"))
+			const auto str = std::string(name);
+			if (str == "g_TeamColor_EnemyTeam")
 			{
-				// A dark red
-				auto* colorlindEnemy = Colors::ColorEnemy.get<float*>();
-				color[0] = colorlindEnemy[0];
-				color[1] = colorlindEnemy[1];
-				color[2] = colorlindEnemy[2];
-				color[3] = colorlindEnemy[3];
+				auto* colorblindEnemy = Colors::ColorEnemyColorBlind->current.color;
+				expandedColor[0] = static_cast<float>(colorblindEnemy[0]) / 255.0f;
+				expandedColor[1] = static_cast<float>(colorblindEnemy[1]) / 255.0f;
+				expandedColor[2] = static_cast<float>(colorblindEnemy[2]) / 255.0f;
+				expandedColor[3] = static_cast<float>(colorblindEnemy[3]) / 255.0f;
 				return false;
 			}
-			else if (!str.compare("g_TeamColor_MyTeam"))
+			else if (str == "g_TeamColor_MyTeam")
 			{
-				// A bright yellow
-				auto* colorblindAlly = Colors::ColorAlly.get<float*>();
-				color[0] = colorblindAlly[0];
-				color[1] = colorblindAlly[1];
-				color[2] = colorblindAlly[2];
-				color[3] = colorblindAlly[3];
+				auto* colorblindAlly = Colors::ColorAllyColorBlind->current.color;
+				expandedColor[0] = static_cast<float>(colorblindAlly[0]) / 255.0f;
+				expandedColor[1] = static_cast<float>(colorblindAlly[1]) / 255.0f;
+				expandedColor[2] = static_cast<float>(colorblindAlly[2]) / 255.0f;
+				expandedColor[3] = static_cast<float>(colorblindAlly[3]) / 255.0f;
 				return false;
 			}
 		}
@@ -279,8 +277,10 @@ namespace Components
 	{
 		// Add a colorblind mode for team colors
 		Colors::ColorBlind = Dvar::Register<bool>("r_colorBlindTeams", false, Game::dvar_flag::DVAR_FLAG_SAVED, "Use color-blindness-friendly colors for ingame team names");
-		Colors::ColorEnemy = Game::Dvar_RegisterVec4("g_TeamColor_EnemyTeam_Color", 0.659f, 0.088f, 0.145f, 1, 0, 1, Game::dvar_flag::DVAR_FLAG_SAVED, "Enemy team color");
-		Colors::ColorAlly = Game::Dvar_RegisterVec4("g_TeamColor_MyTeam_Color", 1, 0.859f, 0.125f, 1, 0, 1, Game::dvar_flag::DVAR_FLAG_SAVED, "Allied team color");
+		// A dark red
+		Colors::ColorEnemyColorBlind = Game::Dvar_RegisterColor("g_ColorBlind_EnemyTeam", 0.659f, 0.088f, 0.145f, 1, Game::dvar_flag::DVAR_FLAG_SAVED, "Enemy team color for colorblind mode");
+		// A bright yellow
+		Colors::ColorAllyColorBlind = Game::Dvar_RegisterColor("g_ColorBlind_MyTeam", 1, 0.859f, 0.125f, 1, Game::dvar_flag::DVAR_FLAG_SAVED, "Ally team color for colorblind mode");
 		Utils::Hook(0x406530, Colors::GetUnpackedColorByNameStub, HOOK_JUMP).install()->quick();
 
 		// Disable SV_UpdateUserinfo_f, to block changing the name ingame

--- a/src/Components/Modules/Colors.cpp
+++ b/src/Components/Modules/Colors.cpp
@@ -218,8 +218,41 @@ namespace Components
 		}
 	}
 
+
+	// Patches team overhead normally
+	signed int __cdecl Colors::Dvar_GetUnpackedColorByName(const char* name, float* color) {
+
+		if (Dvar::Var("r_colorBlindTeams").get<bool>()) {
+			auto str = std::string(name);
+			if (str.compare("g_TeamColor_EnemyTeam") == 0) {
+				// A dark red
+				color[0] = 0.659f;
+				color[1] = 0.088f;
+				color[2] = 0.145f;
+				return 0;
+			}
+			else if (str.compare("g_TeamColor_MyTeam") == 0) {
+				// A bright yellow
+				color[0] = 1.f;
+				color[1] = 0.859f;
+				color[2] = 0.125f;
+				return 0;
+			}
+		}
+
+		return Utils::Hook::Call<signed int(const char*, float*)>(0x406530)(name, color);
+	}
+
 	Colors::Colors()
 	{
+		// Add a colorblind mode for team colors
+		Dvar::Register<bool>("r_colorBlindTeams", false, Game::dvar_flag::DVAR_FLAG_SAVED, "Use color-blindness-friendly colors for ingame team names");
+		Utils::Hook(0x4C09BE, Colors::Dvar_GetUnpackedColorByName, HOOK_CALL).install()->quick();
+		Utils::Hook(0x583661, Colors::Dvar_GetUnpackedColorByName, HOOK_CALL).install()->quick();
+		Utils::Hook(0x5836A5, Colors::Dvar_GetUnpackedColorByName, HOOK_CALL).install()->quick();
+		Utils::Hook(0x4264FC, Colors::Dvar_GetUnpackedColorByName, HOOK_CALL).install()->quick();
+		Utils::Hook(0x4264E5, Colors::Dvar_GetUnpackedColorByName, HOOK_CALL).install()->quick();
+
 		// Disable SV_UpdateUserinfo_f, to block changing the name ingame
 		Utils::Hook::Set<BYTE>(0x6258D0, 0xC3);
 

--- a/src/Components/Modules/Colors.cpp
+++ b/src/Components/Modules/Colors.cpp
@@ -268,8 +268,8 @@ namespace Components
 			mov eax, [esp + 8]
 			push edi
 			mov edi, dword ptr[esp + 4h]
-			mov ecx, 406535h
-			jmp ecx
+			push 406535h
+			retn
 
 		dontContinue:
 			xor eax, eax

--- a/src/Components/Modules/Colors.cpp
+++ b/src/Components/Modules/Colors.cpp
@@ -225,7 +225,7 @@ namespace Components
 		if (Colors::ColorBlind.get<bool>())
 		{
 			auto str = std::string(name);
-			if (str.compare("g_TeamColor_EnemyTeam") == 0)
+			if (!str.compare("g_TeamColor_EnemyTeam"))
 			{
 				// A dark red
 				color[0] = 0.659f;
@@ -233,7 +233,7 @@ namespace Components
 				color[2] = 0.145f;
 				return false;
 			}
-			else if (str.compare("g_TeamColor_MyTeam") == 0)
+			else if (!str.compare("g_TeamColor_MyTeam"))
 			{
 				// A bright yellow
 				color[0] = 1.f;
@@ -250,28 +250,20 @@ namespace Components
 	{
 		__asm
 		{
-			push eax
-			pushad
-
-			push [esp + 2Ch]
-			push [esp + 2Ch]
+			push [esp + 8h]
+			push [esp + 8h]
 			call Colors::Dvar_GetUnpackedColorByName
 			add esp, 8h
 
-			mov [esp + 20h], eax
-			popad
-			pop eax
-
 			test al, al
-			jz dontContinue
+			jnz continue
 
-			push edi
-			mov edi, dword ptr[esp + 4h]
-			push 406535h
 			retn
 
-		dontContinue:
-			xor eax, eax
+		continue:
+			push edi
+			mov edi, [esp + 8h]
+			push 406535h
 			retn
 		}
 	}

--- a/src/Components/Modules/Colors.cpp
+++ b/src/Components/Modules/Colors.cpp
@@ -3,6 +3,7 @@
 namespace Components
 {
 	Dvar::Var Colors::NewColors;
+	Dvar::Var Colors::ColorBlind;
 	std::vector<DWORD> Colors::ColorTable;
 
 	DWORD Colors::HsvToRgb(Colors::HsvColor hsv)
@@ -220,18 +221,21 @@ namespace Components
 
 
 	// Patches team overhead normally
-	signed int __cdecl Colors::Dvar_GetUnpackedColorByName(const char* name, float* color) {
-
-		if (Dvar::Var("r_colorBlindTeams").get<bool>()) {
+	signed int __cdecl Colors::Dvar_GetUnpackedColorByName(const char* name, float* color)
+	{
+		if (Colors::ColorBlind.get<bool>())
+		{
 			auto str = std::string(name);
-			if (str.compare("g_TeamColor_EnemyTeam") == 0) {
+			if (str.compare("g_TeamColor_EnemyTeam") == 0)
+			{
 				// A dark red
 				color[0] = 0.659f;
 				color[1] = 0.088f;
 				color[2] = 0.145f;
 				return 0;
 			}
-			else if (str.compare("g_TeamColor_MyTeam") == 0) {
+			else if (str.compare("g_TeamColor_MyTeam") == 0)
+			{
 				// A bright yellow
 				color[0] = 1.f;
 				color[1] = 0.859f;
@@ -246,7 +250,7 @@ namespace Components
 	Colors::Colors()
 	{
 		// Add a colorblind mode for team colors
-		Dvar::Register<bool>("r_colorBlindTeams", false, Game::dvar_flag::DVAR_FLAG_SAVED, "Use color-blindness-friendly colors for ingame team names");
+		Colors::ColorBlind = Dvar::Register<bool>("r_colorBlindTeams", false, Game::dvar_flag::DVAR_FLAG_SAVED, "Use color-blindness-friendly colors for ingame team names");
 		Utils::Hook(0x4C09BE, Colors::Dvar_GetUnpackedColorByName, HOOK_CALL).install()->quick();
 		Utils::Hook(0x583661, Colors::Dvar_GetUnpackedColorByName, HOOK_CALL).install()->quick();
 		Utils::Hook(0x5836A5, Colors::Dvar_GetUnpackedColorByName, HOOK_CALL).install()->quick();
@@ -272,7 +276,7 @@ namespace Components
 		Utils::Hook(0x4AD470, Colors::CleanStrStub, HOOK_JUMP).install()->quick();
 
 		// Register dvar
-		Colors::NewColors = Dvar::Register<bool>("cg_newColors", true, Game::dvar_flag::DVAR_FLAG_SAVED, "Use Warfare² color code style.");
+		Colors::NewColors = Dvar::Register<bool>("cg_newColors", true, Game::dvar_flag::DVAR_FLAG_SAVED, "Use WarfareÂ² color code style.");
 		Game::Dvar_RegisterColor("sv_customTextColor", 1, 0.7f, 0, 1, Game::dvar_flag::DVAR_FLAG_REPLICATED, "Color for the extended color code.");
 		Dvar::Register<bool>("sv_allowColoredNames", true, Game::dvar_flag::DVAR_FLAG_NONE, "Allow colored names on the server");
 

--- a/src/Components/Modules/Colors.cpp
+++ b/src/Components/Modules/Colors.cpp
@@ -230,6 +230,7 @@ namespace Components
 			const auto str = std::string(name);
 			if (str == "g_TeamColor_EnemyTeam")
 			{
+				// Dvar_GetUnpackedColor
 				auto* colorblindEnemy = Colors::ColorEnemyColorBlind->current.color;
 				expandedColor[0] = static_cast<float>(colorblindEnemy[0]) / 255.0f;
 				expandedColor[1] = static_cast<float>(colorblindEnemy[1]) / 255.0f;
@@ -239,6 +240,7 @@ namespace Components
 			}
 			else if (str == "g_TeamColor_MyTeam")
 			{
+				// Dvar_GetUnpackedColor
 				auto* colorblindAlly = Colors::ColorAllyColorBlind->current.color;
 				expandedColor[0] = static_cast<float>(colorblindAlly[0]) / 255.0f;
 				expandedColor[1] = static_cast<float>(colorblindAlly[1]) / 255.0f;

--- a/src/Components/Modules/Colors.cpp
+++ b/src/Components/Modules/Colors.cpp
@@ -293,7 +293,7 @@ namespace Components
 		Utils::Hook(0x4AD470, Colors::CleanStrStub, HOOK_JUMP).install()->quick();
 
 		// Register dvar
-		Colors::NewColors = Dvar::Register<bool>("cg_newColors", true, Game::dvar_flag::DVAR_FLAG_SAVED, "Use Warfare² color code style.");
+		Colors::NewColors = Dvar::Register<bool>("cg_newColors", true, Game::dvar_flag::DVAR_FLAG_SAVED, "Use Warfare 2 color code style.");
 		Game::Dvar_RegisterColor("sv_customTextColor", 1, 0.7f, 0, 1, Game::dvar_flag::DVAR_FLAG_REPLICATED, "Color for the extended color code.");
 		Dvar::Register<bool>("sv_allowColoredNames", true, Game::dvar_flag::DVAR_FLAG_NONE, "Allow colored names on the server");
 

--- a/src/Components/Modules/Colors.cpp
+++ b/src/Components/Modules/Colors.cpp
@@ -265,7 +265,6 @@ namespace Components
 			test al, al
 			jz dontContinue
 
-			mov eax, [esp + 8]
 			push edi
 			mov edi, dword ptr[esp + 4h]
 			push 406535h

--- a/src/Components/Modules/Colors.cpp
+++ b/src/Components/Modules/Colors.cpp
@@ -219,7 +219,6 @@ namespace Components
 		}
 	}
 
-
 	// Patches team overhead normally
 	bool Colors::Dvar_GetUnpackedColorByName(const char* name, float* color)
 	{
@@ -260,7 +259,6 @@ namespace Components
 			add esp, 8h
 
 			mov [esp + 20h], eax
-
 			popad
 			pop eax
 
@@ -270,7 +268,6 @@ namespace Components
 			mov eax, [esp + 8]
 			push edi
 			mov edi, dword ptr[esp + 4h]
-
 			mov ecx, 406535h
 			jmp ecx
 

--- a/src/Components/Modules/Colors.cpp
+++ b/src/Components/Modules/Colors.cpp
@@ -4,6 +4,9 @@ namespace Components
 {
 	Dvar::Var Colors::NewColors;
 	Dvar::Var Colors::ColorBlind;
+	Dvar::Var Colors::ColorAlly;
+	Dvar::Var Colors::ColorEnemy;
+
 	std::vector<DWORD> Colors::ColorTable;
 
 	DWORD Colors::HsvToRgb(Colors::HsvColor hsv)
@@ -228,17 +231,21 @@ namespace Components
 			if (!str.compare("g_TeamColor_EnemyTeam"))
 			{
 				// A dark red
-				color[0] = 0.659f;
-				color[1] = 0.088f;
-				color[2] = 0.145f;
+				auto* colorlindEnemy = Colors::ColorEnemy.get<float*>();
+				color[0] = colorlindEnemy[0];
+				color[1] = colorlindEnemy[1];
+				color[2] = colorlindEnemy[2];
+				color[3] = colorlindEnemy[3];
 				return false;
 			}
 			else if (!str.compare("g_TeamColor_MyTeam"))
 			{
 				// A bright yellow
-				color[0] = 1.f;
-				color[1] = 0.859f;
-				color[2] = 0.125f;
+				auto* colorblindAlly = Colors::ColorAlly.get<float*>();
+				color[0] = colorblindAlly[0];
+				color[1] = colorblindAlly[1];
+				color[2] = colorblindAlly[2];
+				color[3] = colorblindAlly[3];
 				return false;
 			}
 		}
@@ -272,6 +279,8 @@ namespace Components
 	{
 		// Add a colorblind mode for team colors
 		Colors::ColorBlind = Dvar::Register<bool>("r_colorBlindTeams", false, Game::dvar_flag::DVAR_FLAG_SAVED, "Use color-blindness-friendly colors for ingame team names");
+		Colors::ColorEnemy = Game::Dvar_RegisterVec4("g_TeamColor_EnemyTeam_Color", 0.659f, 0.088f, 0.145f, 1, 0, 1, Game::dvar_flag::DVAR_FLAG_SAVED, "Enemy team color");
+		Colors::ColorAlly = Game::Dvar_RegisterVec4("g_TeamColor_MyTeam_Color", 1, 0.859f, 0.125f, 1, 0, 1, Game::dvar_flag::DVAR_FLAG_SAVED, "Allied team color");
 		Utils::Hook(0x406530, Colors::GetUnpackedColorByNameStub, HOOK_JUMP).install()->quick();
 
 		// Disable SV_UpdateUserinfo_f, to block changing the name ingame

--- a/src/Components/Modules/Colors.cpp
+++ b/src/Components/Modules/Colors.cpp
@@ -221,7 +221,7 @@ namespace Components
 
 
 	// Patches team overhead normally
-	int Colors::Dvar_GetUnpackedColorByName(const char* name, float* color)
+	bool Colors::Dvar_GetUnpackedColorByName(const char* name, float* color)
 	{
 		if (Colors::ColorBlind.get<bool>())
 		{
@@ -232,7 +232,7 @@ namespace Components
 				color[0] = 0.659f;
 				color[1] = 0.088f;
 				color[2] = 0.145f;
-				return 0;
+				return false;
 			}
 			else if (str.compare("g_TeamColor_MyTeam") == 0)
 			{
@@ -240,11 +240,11 @@ namespace Components
 				color[0] = 1.f;
 				color[1] = 0.859f;
 				color[2] = 0.125f;
-				return 0;
+				return false;
 			}
 		}
 
-		return 1;
+		return true;
 	}
 
 	__declspec(naked) void Colors::GetUnpackedColorByNameStub()
@@ -255,7 +255,7 @@ namespace Components
 			pushad
 
 			push [esp + 2Ch]
-			push [esp + 2Ch];
+			push [esp + 2Ch]
 			call Colors::Dvar_GetUnpackedColorByName
 			add esp, 8h
 
@@ -264,17 +264,18 @@ namespace Components
 			popad
 			pop eax
 
-			test eax, eax
-			jnz continue
+			test al, al
+			jz dontContinue
 
-			xor eax, eax
-			retn
-
-		continue:
+			mov eax, [esp + 8]
 			push edi
 			mov edi, dword ptr[esp + 4h]
 
-			push 406535h
+			mov ecx, 406535h
+			jmp ecx
+
+		dontContinue:
+			xor eax, eax
 			retn
 		}
 	}

--- a/src/Components/Modules/Colors.hpp
+++ b/src/Components/Modules/Colors.hpp
@@ -22,6 +22,7 @@ namespace Components
 		};
 
 		static Dvar::Var NewColors;
+		static Dvar::Var ColorBlind;
 
 		static DWORD HsvToRgb(HsvColor hsv);
 

--- a/src/Components/Modules/Colors.hpp
+++ b/src/Components/Modules/Colors.hpp
@@ -23,6 +23,8 @@ namespace Components
 
 		static Dvar::Var NewColors;
 		static Dvar::Var ColorBlind;
+		static Dvar::Var ColorAlly;
+		static Dvar::Var ColorEnemy;
 
 		static DWORD HsvToRgb(HsvColor hsv);
 

--- a/src/Components/Modules/Colors.hpp
+++ b/src/Components/Modules/Colors.hpp
@@ -23,8 +23,8 @@ namespace Components
 
 		static Dvar::Var NewColors;
 		static Dvar::Var ColorBlind;
-		static Dvar::Var ColorAlly;
-		static Dvar::Var ColorEnemy;
+		static Game::dvar_t* ColorAllyColorBlind;
+		static Game::dvar_t* ColorEnemyColorBlind;
 
 		static DWORD HsvToRgb(HsvColor hsv);
 
@@ -38,7 +38,7 @@ namespace Components
 		static void LookupColor(DWORD* color, char index);
 		static void LookupColorStub();
 		static char* CleanStrStub(char* string);
-		static bool Dvar_GetUnpackedColorByName(const char* name, float* color);
+		static bool Dvar_GetUnpackedColorByName(const char* name, float* expandedColor);
 		static void GetUnpackedColorByNameStub();
 		static std::vector<DWORD> ColorTable;
 	};

--- a/src/Components/Modules/Colors.hpp
+++ b/src/Components/Modules/Colors.hpp
@@ -36,7 +36,7 @@ namespace Components
 		static void LookupColor(DWORD* color, char index);
 		static void LookupColorStub();
 		static char* CleanStrStub(char* string);
-		static int Dvar_GetUnpackedColorByName(const char* name, float* color);
+		static bool Dvar_GetUnpackedColorByName(const char* name, float* color);
 		static void GetUnpackedColorByNameStub();
 		static std::vector<DWORD> ColorTable;
 	};

--- a/src/Components/Modules/Colors.hpp
+++ b/src/Components/Modules/Colors.hpp
@@ -35,6 +35,7 @@ namespace Components
 		static void LookupColor(DWORD* color, char index);
 		static void LookupColorStub();
 		static char* CleanStrStub(char* string);
+		static signed int Dvar_GetUnpackedColorByName(const char* name, float* color);
 		static std::vector<DWORD> ColorTable;
 	};
 }

--- a/src/Components/Modules/Colors.hpp
+++ b/src/Components/Modules/Colors.hpp
@@ -36,7 +36,8 @@ namespace Components
 		static void LookupColor(DWORD* color, char index);
 		static void LookupColorStub();
 		static char* CleanStrStub(char* string);
-		static signed int Dvar_GetUnpackedColorByName(const char* name, float* color);
+		static int Dvar_GetUnpackedColorByName(const char* name, float* color);
+		static void GetUnpackedColorByNameStub();
 		static std::vector<DWORD> ColorTable;
 	};
 }

--- a/src/Components/Modules/Localization.cpp
+++ b/src/Components/Modules/Localization.cpp
@@ -193,6 +193,7 @@ namespace Components
 			"Killera",
 			"Lithium",
 			"Louvenarde",
+			"FutureRave",
 			"OneFourOne",
 			"quaK",
 			"RaidMax",

--- a/src/Game/Functions.cpp
+++ b/src/Game/Functions.cpp
@@ -99,11 +99,11 @@ namespace Game
 	Dvar_RegisterFloat_t Dvar_RegisterFloat = Dvar_RegisterFloat_t(0x648440);
 	Dvar_RegisterVec2_t Dvar_RegisterVec2 = Dvar_RegisterVec2_t(0x4F6070);
 	Dvar_RegisterVec3_t Dvar_RegisterVec3 = Dvar_RegisterVec3_t(0x4EF8E0);
-	Dvar_RegisterVec4_t Dvar_RegisterVec4 = Dvar_RegisterVec4_t(0x4F28E0);
+	Dvar_RegisterVec4_t Dvar_RegisterVec4 = Dvar_RegisterVec4_t(0x471500);
 	Dvar_RegisterInt_t Dvar_RegisterInt = Dvar_RegisterInt_t(0x479830);
 	Dvar_RegisterEnum_t Dvar_RegisterEnum = Dvar_RegisterEnum_t(0x412E40);
 	Dvar_RegisterString_t Dvar_RegisterString = Dvar_RegisterString_t(0x4FC7E0);
-	Dvar_RegisterColor_t Dvar_RegisterColor = Dvar_RegisterColor_t(0x4F28E0);//0x471500;
+	Dvar_RegisterColor_t Dvar_RegisterColor = Dvar_RegisterColor_t(0x4F28E0);
 
 	Dvar_GetUnpackedColorByName_t Dvar_GetUnpackedColorByName = Dvar_GetUnpackedColorByName_t(0x406530);
 	Dvar_FindVar_t Dvar_FindVar = Dvar_FindVar_t(0x4D5390);

--- a/src/Game/Structs.hpp
+++ b/src/Game/Structs.hpp
@@ -2347,7 +2347,7 @@ namespace Game
 		float value;
 		float vector[4];
 		const char *string;
-		char color[4];
+		unsigned char color[4];
 	};
 
 	struct $BFBB53559BEAC4289F32B924847E59CB


### PR DESCRIPTION
I could use a CFG for this, but since the colors are set from GSC, possibly in multiple places, that would require modifying _them_ and so... well i think it's good colorblind people are allowed to enforce whatever color they need on their client, regardless of what the server owner decided, i suppose? 🤔  :) 