### PR TITLE
Fix codol dynent patch bug

### DIFF
--- a/src/Components/Modules/QuickPatch.cpp
+++ b/src/Components/Modules/QuickPatch.cpp
@@ -380,10 +380,10 @@ namespace Components
 		}
 	}
 
-	bool QuickPatch::IsDynClassnameStub(char* a1) 
+	BOOL QuickPatch::IsDynClassnameStub(char* a1) 
 	{
 		auto version = Zones::GetEntitiesZoneVersion();
-
+		
 		if (version >= VERSION_LATEST_CODO)
 		{
 			for (auto i = 0; i < Game::spawnVars->numSpawnVars; i++)
@@ -399,13 +399,13 @@ namespace Components
 				{
 					// This will prevent spawning of any entity that contains "script_specialops: '1'" 
 					// It removes extra hitboxes / meshes on 461+ CODO multiplayer maps
-					return true;
+					return TRUE;
 				}
 			}
 		}
 
 		// Passthrough to the game's own IsDynClassname
-		return Utils::Hook::Call<bool(char*)>(0x444810)(a1);
+		return Utils::Hook::Call<BOOL(char*)>(0x444810)(a1);
 	}
   
 	QuickPatch::QuickPatch()

--- a/src/Components/Modules/QuickPatch.hpp
+++ b/src/Components/Modules/QuickPatch.hpp
@@ -47,6 +47,6 @@ namespace Components
 		static void PlayerCollisionStub();
 		static Game::dvar_t* g_playerEjection;
 		static void PlayerEjectionStub();
-		static bool IsDynClassnameStub(char* a1);
+		static BOOL IsDynClassnameStub(char* a1);
 	};
 }


### PR DESCRIPTION
The patch doesn't respect that the return type should be 32bit BOOL and has a 8bit bool instead.
That causes a game freeze or kick into main menu on loading into private match when in Release mode.
This is due to compiler optimizations not setting the whole 32bit value when returning.