### PR TITLE
Sound mutex workaround

### DIFF
--- a/src/Components/Loader.cpp
+++ b/src/Components/Loader.cpp
@@ -101,6 +101,7 @@ namespace Components
 		Loader::Register(new StructuredData());
 		Loader::Register(new ConnectProtocol());
 		Loader::Register(new StartupMessages());
+		Loader::Register(new SoundMutexFix());
 
 		Loader::Register(new Client());
 

--- a/src/Components/Loader.hpp
+++ b/src/Components/Loader.hpp
@@ -130,5 +130,6 @@ namespace Components
 #include "Modules/ConnectProtocol.hpp"
 #include "Modules/StartupMessages.hpp"
 #include "Modules/Stats.hpp"
+#include "Modules/SoundMutexFix.hpp"
 
 #include "Modules/Client.hpp"

--- a/src/Components/Modules/SoundMutexFix.cpp
+++ b/src/Components/Modules/SoundMutexFix.cpp
@@ -2,42 +2,38 @@
 
 namespace Components
 {
-	/// This component is a workaround for issue https://github.com/XLabsProject/iw4x-client/issues/80
-	/// In case the link goes down, this is a "game hangs randomly" issue:
-	/// 
-	/// Investigations on the issue pointed out it comes from a situation on Intel processors where
-	///		WaitForSingleObjectA is ignored by a thread, for some (?) reason.
-	/// 
-	/// This locks up the game randomly, mostly at the end of rounds or when too many things happen at
-	///		once, due to trying to stop sounds (AIL_Stop_sounds) and playing streams at the same time,
-	///		rushing for the same resource via AIL_lock_mutex. 
-	/// 
-	/// This bug has been reproduced on	mp_terminal, mp_overgrown, mp_rust, with and without bots,
-	///		and so far this has been the only way to circumvent it afaik. This component wraps
-	///		miles' mutex into another mutex, created below, and for some reason (?) that mutex is 
-	///		respected when miles' is not.
-	/// 
-	/// As soon as a real fix is found, please discard this fix. In the meantime, it should not
-	///		have side effects too bad - worst case it might cause a slight performance drop during
-	///		team switch and intermission.
-	/// 
+	// This component is a workaround for issue https://github.com/XLabsProject/iw4x-client/issues/80
+	// In case the link goes down, this is a "game hangs randomly" issue:
+	// 
+	// Investigations on the issue pointed out it comes from a situation on Intel processors where
+	//		WaitForSingleObjectA is ignored by a thread, for some (?) reason.
+	// 
+	// This locks up the game randomly, mostly at the end of rounds or when too many things happen at
+	//		once, due to trying to stop sounds (AIL_Stop_sounds) and playing streams at the same time,
+	//		rushing for the same resource via AIL_lock_mutex. 
+	// 
+	// This bug has been reproduced on	mp_terminal, mp_overgrown, mp_rust, with and without bots,
+	//		and so far this has been the only way to circumvent it afaik. This component wraps
+	//		miles' mutex into another mutex, created below, and for some reason (?) that mutex is 
+	//		respected when miles' is not.
+	// 
+	// As soon as a real fix is found, please discard this fix. In the meantime, it should not
+	//		have side effects too bad - worst case it might cause a slight performance drop during
+	//		team switch and intermission.
+	// 
 
 	std::mutex SoundMutexFix::snd_mutex;
 
-	static void __stdcall LockSoundMutex(int unk)
+	void __stdcall SoundMutexFix::LockSoundMutex(int unk)
 	{
 		std::lock_guard lock(SoundMutexFix::snd_mutex);
 
 		DWORD funcPtr = *reinterpret_cast<DWORD*>(0x6D7554); // AIL_close_stream
-		((void(__stdcall*)(int unk))(funcPtr))(unk);
+		Utils::Hook::Call<void __stdcall(int)>(funcPtr)(unk);
 	}
 
 	SoundMutexFix::SoundMutexFix()
 	{
-		Utils::Hook(0x689EFE, &LockSoundMutex, HOOK_JUMP).install()->quick();
-	}
-
-	SoundMutexFix::~SoundMutexFix()
-	{
+		Utils::Hook(0x689EFE, &SoundMutexFix::LockSoundMutex, HOOK_JUMP).install()->quick();
 	}
 }

--- a/src/Components/Modules/SoundMutexFix.cpp
+++ b/src/Components/Modules/SoundMutexFix.cpp
@@ -1,0 +1,43 @@
+#include "STDInclude.hpp"
+
+namespace Components
+{
+	/// This component is a workaround for issue https://github.com/XLabsProject/iw4x-client/issues/80
+	/// In case the link goes down, this is a "game hangs randomly" issue:
+	/// 
+	/// Investigations on the issue pointed out it comes from a situation on Intel processors where
+	///		WaitForSingleObjectA is ignored by a thread, for some (?) reason.
+	/// 
+	/// This locks up the game randomly, mostly at the end of rounds or when too many things happen at
+	///		once, due to trying to stop sounds (AIL_Stop_sounds) and playing streams at the same time,
+	///		rushing for the same resource via AIL_lock_mutex. 
+	/// 
+	/// This bug has been reproduced on	mp_terminal, mp_overgrown, mp_rust, with and without bots,
+	///		and so far this has been the only way to circumvent it afaik. This component wraps
+	///		miles' mutex into another mutex, created below, and for some reason (?) that mutex is 
+	///		respected when miles' is not.
+	/// 
+	/// As soon as a real fix is found, please discard this fix. In the meantime, it should not
+	///		have side effects too bad - worst case it might cause a slight performance drop during
+	///		team switch and intermission.
+	/// 
+
+	std::mutex SoundMutexFix::snd_mutex;
+
+	static void __stdcall LockSoundMutex(int unk)
+	{
+		std::lock_guard lock(SoundMutexFix::snd_mutex);
+
+		DWORD funcPtr = *reinterpret_cast<DWORD*>(0x6D7554); // AIL_close_stream
+		((void(__stdcall*)(int unk))(funcPtr))(unk);
+	}
+
+	SoundMutexFix::SoundMutexFix()
+	{
+		Utils::Hook(0x689EFE, &LockSoundMutex, HOOK_JUMP).install()->quick();
+	}
+
+	SoundMutexFix::~SoundMutexFix()
+	{
+	}
+}

--- a/src/Components/Modules/SoundMutexFix.hpp
+++ b/src/Components/Modules/SoundMutexFix.hpp
@@ -1,4 +1,5 @@
 #pragma once
+#include <mutex>
 
 namespace Components
 {
@@ -6,9 +7,9 @@ namespace Components
 	{
 	public:
 		SoundMutexFix();
-		~SoundMutexFix();
-
-		static void SND_StopStreamChannelHook(int channel);
+		
+	private:
 		static std::mutex snd_mutex;
+		static void LockSoundMutex(int unk);
 	};
 }

--- a/src/Components/Modules/SoundMutexFix.hpp
+++ b/src/Components/Modules/SoundMutexFix.hpp
@@ -1,0 +1,14 @@
+#pragma once
+
+namespace Components
+{
+	class SoundMutexFix : public Component
+	{
+	public:
+		SoundMutexFix();
+		~SoundMutexFix();
+
+		static void SND_StopStreamChannelHook(int channel);
+		static std::mutex snd_mutex;
+	};
+}


### PR DESCRIPTION
This is a fix for https://github.com/XLabsProject/iw4x-client/issues/80, or rather a workaround.
For reasons explicited in the code, it works "enough" to mitigate the issue and avoid all crashes related to the miles mutex problem, as far as I know.

I've been playing multiple games with this fix for two months with no notable problems, except maybe a slight freeze on round intermission from time to time (was that an avoided crash?). I'm not even sure this was due to the fix or just something that would have occured regardless :D 

So as far as I know this is "safe", but it's also "not great", so - i'm leaving the issue open and hopefully someone can one day come up with a better fix. Kudos to @Laupetin  for helping me investigate this through!