### PR TITLE
slowmofix

### DIFF
--- a/src/Components/Modules/Slowmotion.cpp
+++ b/src/Components/Modules/Slowmotion.cpp
@@ -3,22 +3,35 @@
 namespace Components
 {
 	int SlowMotion::Delay = 0;
-	DWORD applySlowMotionHookLoc = 0x60B2D0;
 
-	void SlowMotion::ApplySlowMotionStub(int timePassed)
+	void SlowMotion::ApplySlowMotion(int timePassed)
 	{
 		if (SlowMotion::Delay <= 0)
 		{
-			__asm
-			{
-				push timePassed
-				call applySlowMotionHookLoc
-				add esp, 4h
-			}
+			Utils::Hook::Call<void(int)>(0x60B2D0)(timePassed);
 		}
 		else
+		{
 			SlowMotion::Delay -= timePassed;
+		}
 	}
+
+	__declspec(naked) void SlowMotion::ApplySlowMotionStub()
+	{
+		__asm
+		{
+			pushad
+			push[esp + 18h]
+
+			call SlowMotion::ApplySlowMotion
+
+			add esp, 4
+			popad
+
+			retn
+		}
+	}
+
 	void SlowMotion::SetSlowMotion()
 	{
 		int duration = 1000;
@@ -63,10 +76,10 @@ namespace Components
 
 	void SlowMotion::DrawConnectionInterruptedStub(int /*a1*/)
 	{
-// 		if (!*reinterpret_cast<bool*>(0x1AD8ED0) && !*reinterpret_cast<bool*>(0x1AD8EEC) && !*reinterpret_cast<int*>(0x1AD78F8))
-// 		{
-// 			Utils::Hook::Call<void(int)>(0x454A70)(a1);
-// 		}
+		// 		if (!*reinterpret_cast<bool*>(0x1AD8ED0) && !*reinterpret_cast<bool*>(0x1AD8EEC) && !*reinterpret_cast<int*>(0x1AD78F8))
+		// 		{
+		// 			Utils::Hook::Call<void(int)>(0x454A70)(a1);
+		// 		}
 	}
 
 	SlowMotion::SlowMotion()

--- a/src/Components/Modules/Slowmotion.cpp
+++ b/src/Components/Modules/Slowmotion.cpp
@@ -3,35 +3,22 @@
 namespace Components
 {
 	int SlowMotion::Delay = 0;
+	DWORD applySlowMotionHookLoc = 0x60B2D0;
 
-	void SlowMotion::ApplySlowMotion(int timePassed)
+	void SlowMotion::ApplySlowMotionStub(int timePassed)
 	{
 		if (SlowMotion::Delay <= 0)
 		{
-			Utils::Hook::Call<void(int)>(0x60B2D0)(timePassed);
+			__asm
+			{
+				push timePassed
+				call applySlowMotionHookLoc
+				add esp, 4h
+			}
 		}
 		else
-		{
 			SlowMotion::Delay -= timePassed;
-		}
 	}
-
-	__declspec(naked) void SlowMotion::ApplySlowMotionStub()
-	{
-		__asm
-		{
-			pushad
-			push [esp + 20h]
-
-			call SlowMotion::ApplySlowMotion
-
-			pop ecx
-			popad
-
-			retn
-		}
-	}
-
 	void SlowMotion::SetSlowMotion()
 	{
 		int duration = 1000;

--- a/src/Components/Modules/Slowmotion.hpp
+++ b/src/Components/Modules/Slowmotion.hpp
@@ -14,7 +14,8 @@ namespace Components
 		static int Delay;
 
 		static void SetSlowMotion();
-		static void ApplySlowMotionStub(int timePassed);
+		static void ApplySlowMotion(int timePassed);
+		static void ApplySlowMotionStub();
 
 		static void DrawConnectionInterruptedStub(int a1);
 	};

--- a/src/Components/Modules/Slowmotion.hpp
+++ b/src/Components/Modules/Slowmotion.hpp
@@ -14,8 +14,7 @@ namespace Components
 		static int Delay;
 
 		static void SetSlowMotion();
-		static void ApplySlowMotion(int timePassed);
-		static void ApplySlowMotionStub();
+		static void ApplySlowMotionStub(int timePassed);
 
 		static void DrawConnectionInterruptedStub(int a1);
 	};


### PR DESCRIPTION
This is going to fix time lerp in the SetSlowMotion function

on the current develop version the function right away jumps to the entered timescale and ignores the start parameter