### PR TITLE
Fix 2d material text icons

### DIFF
--- a/src/Components/Modules/Dedicated.cpp
+++ b/src/Components/Modules/Dedicated.cpp
@@ -76,6 +76,29 @@ namespace Components
 		}
 	}
 
+	void Dedicated::StripMaterialTextIcons(char* text)
+	{
+		char* currentChar = text;
+		bool isEscaped = false;
+		while (*currentChar)
+		{
+			if (*currentChar == '^')
+			{
+				isEscaped = true;
+			}
+			else if(isEscaped == true && (*currentChar == '\x01' || *currentChar == '\x02'))
+			{
+				*currentChar = ' ';
+			}
+			else
+			{
+				isEscaped = false;
+			}
+
+			currentChar++;
+		}
+	}
+
 	const char* Dedicated::EvaluateSay(char* text, Game::gentity_t* player)
 	{
 		Dedicated::SendChat = true;
@@ -86,6 +109,8 @@ namespace Components
 			text[1] = text[0];
 			++text;
 		}
+
+		StripMaterialTextIcons(text);
 
 		Game::Scr_AddEntity(player);
 		Game::Scr_AddString(text + 1);

--- a/src/Components/Modules/Dedicated.hpp
+++ b/src/Components/Modules/Dedicated.hpp
@@ -14,6 +14,8 @@ namespace Components
 
 		static void Heartbeat();
 
+		static void StripMaterialTextIcons(char* text);
+
 	private:
 		static bool SendChat;
 

--- a/src/Components/Modules/Materials.cpp
+++ b/src/Components/Modules/Materials.cpp
@@ -161,7 +161,12 @@ namespace Components
 			Materials::ImageNameLength = 4 + length;
 			std::string image(imagePtr, length);
 
-			return Game::DB_FindXAssetHeader(Game::XAssetType::ASSET_TYPE_MATERIAL, image.data()).material;
+			auto* material = Game::DB_FindXAssetHeader(Game::XAssetType::ASSET_TYPE_MATERIAL, image.data()).material;
+
+			if(material == nullptr || material->techniqueSet == nullptr || material->techniqueSet->name == nullptr || strcmp(material->techniqueSet->name, "2d") != 0)
+				return Game::DB_FindXAssetHeader(Game::XAssetType::ASSET_TYPE_MATERIAL, "default").material;
+
+			return material;
 		}
 
 		Materials::ImageNameLength = 4;

--- a/src/Components/Modules/ServerList.cpp
+++ b/src/Components/Modules/ServerList.cpp
@@ -454,9 +454,6 @@ namespace Components
 
 				ServerInfo server;
 				server.hostname = info.get("hostname");
-
-				Dedicated::StripMaterialTextIcons(server.hostname.data());
-
 				server.mapname = info.get("mapname");
 				server.gametype = info.get("gametype");
 				server.shortversion = info.get("shortversion");
@@ -471,6 +468,11 @@ namespace Components
 				server.svRunning = (atoi(info.get("sv_running").data()) != 0);
 				server.ping = (Game::Sys_Milliseconds() - i->sendTime);
 				server.addr = address;
+
+				Dedicated::StripMaterialTextIcons(server.hostname.data());
+				Dedicated::StripMaterialTextIcons(server.mapname.data());
+				Dedicated::StripMaterialTextIcons(server.gametype.data());
+				Dedicated::StripMaterialTextIcons(server.mod.data());
 
 				// Remove server from queue
 				i = ServerList::RefreshContainer.servers.erase(i);

--- a/src/Components/Modules/ServerList.cpp
+++ b/src/Components/Modules/ServerList.cpp
@@ -454,6 +454,9 @@ namespace Components
 
 				ServerInfo server;
 				server.hostname = info.get("hostname");
+
+				Dedicated::StripMaterialTextIcons(server.hostname.data());
+
 				server.mapname = info.get("mapname");
 				server.gametype = info.get("gametype");
 				server.shortversion = info.get("shortversion");


### PR DESCRIPTION
Make sure that material text icons that are not 2D do not cause issues anymore.

Also strips material text icons entirely for chat messages and server names in the serverlist.