### PR TITLE
Ignore servers in serverlist that specify an invalid player count

### DIFF
--- a/src/Components/Modules/ServerList.cpp
+++ b/src/Components/Modules/ServerList.cpp
@@ -472,6 +472,11 @@ namespace Components
 				// Remove server from queue
 				i = ServerList::RefreshContainer.servers.erase(i);
 
+				// Servers with more than 18 players or less than 0 players are faking for sure
+				// So lets ignore those
+				if (server.clients > 18 || server.maxClients > 18 || server.clients < 0 || server.maxClients < 0)
+					return;
+
 				// Check if already inserted and remove
 				auto list = ServerList::GetList();
 				if (!list) return;


### PR DESCRIPTION
Filter out any server that answer with a server info that specifies a player count that is greater than 18 or lower than 0.