### PR TITLE
Add Playstation style flavor to gamepad buttons

### DIFF
--- a/src/Components/Modules/Gamepad.cpp
+++ b/src/Components/Modules/Gamepad.cpp
@@ -155,6 +155,7 @@ namespace Components
     Dvar::Var Gamepad::gpad_debug;
     Dvar::Var Gamepad::gpad_present;
     Dvar::Var Gamepad::gpad_in_use;
+    Dvar::Var Gamepad::gpad_style;
     Dvar::Var Gamepad::gpad_sticksConfig;
     Dvar::Var Gamepad::gpad_buttonConfig;
     Dvar::Var Gamepad::gpad_menu_scroll_delay_first;
@@ -1694,6 +1695,7 @@ namespace Components
         gpad_debug = Dvar::Register<bool>("gpad_debug", false, Game::DVAR_FLAG_NONE, "Game pad debugging");
         gpad_present = Dvar::Register<bool>("gpad_present", false, Game::DVAR_FLAG_NONE, "Game pad present");
         gpad_in_use = Dvar::Register<bool>("gpad_in_use", false, Game::DVAR_FLAG_NONE, "A game pad is in use");
+        gpad_style = Dvar::Register<bool>("gpad_style", false, Game::DVAR_FLAG_SAVED, "Switch between Xbox and PS HUD");
         gpad_sticksConfig = Dvar::Register<const char*>("gpad_sticksConfig", "", Game::DVAR_FLAG_SAVED, "Game pad stick configuration");
         gpad_buttonConfig = Dvar::Register<const char*>("gpad_buttonConfig", "", Game::DVAR_FLAG_SAVED, "Game pad button configuration");
         gpad_menu_scroll_delay_first = Dvar::Register<int>("gpad_menu_scroll_delay_first", 420, 0, 1000, Game::DVAR_FLAG_SAVED, "Menu scroll key-repeat delay, for the first repeat, in milliseconds");

--- a/src/Components/Modules/Gamepad.hpp
+++ b/src/Components/Modules/Gamepad.hpp
@@ -51,9 +51,11 @@ namespace Components
         static const char* gamePadMappingTypeNames[];
         static Game::keyNum_t menuScrollButtonList[];
         static Game::keyname_t extendedKeyNames[];
-        static Game::keyname_t extendedLocalizedKeyNames[];
+        static Game::keyname_t extendedLocalizedKeyNamesXenon[];
+        static Game::keyname_t extendedLocalizedKeyNamesPs3[];
         static Game::keyname_t combinedKeyNames[];
-        static Game::keyname_t combinedLocalizedKeyNames[];
+        static Game::keyname_t combinedLocalizedKeyNamesXenon[];
+        static Game::keyname_t combinedLocalizedKeyNamesPs3[];
         static ControllerMenuKeyMapping controllerMenuKeyMappings[];
 
         static GamePad gamePads[Game::MAX_GAMEPADS];
@@ -193,6 +195,9 @@ namespace Components
         static void CL_KeyEvent_Hk(int localClientNum, int key, int down, unsigned int time);
         static int CL_MouseEvent_Hk(int x, int y, int dx, int dy);
         static bool UI_RefreshViewport_Hk();
+
+        static Game::keyname_t* GetLocalizedKeyNameMap();
+        static void GetLocalizedKeyName_Stub();
         static void CreateKeyNameMap();
     };
 }

--- a/src/Components/Modules/Gamepad.hpp
+++ b/src/Components/Modules/Gamepad.hpp
@@ -65,6 +65,7 @@ namespace Components
         static Dvar::Var gpad_debug;
         static Dvar::Var gpad_present;
         static Dvar::Var gpad_in_use;
+        static Dvar::Var gpad_style;
         static Dvar::Var gpad_sticksConfig;
         static Dvar::Var gpad_buttonConfig;
         static Dvar::Var gpad_menu_scroll_delay_first;

--- a/src/Components/Modules/Localization.cpp
+++ b/src/Components/Modules/Localization.cpp
@@ -181,6 +181,7 @@ namespace Components
 			"a231",
 			"AmateurHailbut",
 			"Aoki",
+			"Chase",
 			"civil",
 			"Dasfonia",
 			"Deity",


### PR DESCRIPTION
This swaps localized button textures from their xbox versions to their playstation versions whenever the style dvar is set to 1