### PR TITLE
[Movement] Add customizable speed scale for stance

### DIFF
--- a/src/Components/Loader.cpp
+++ b/src/Components/Loader.cpp
@@ -104,6 +104,7 @@ namespace Components
 		Loader::Register(new Gamepad());
 		Loader::Register(new Chat());
 		Loader::Register(new TextRenderer());
+		Loader::Register(new Movement());
 
 		Loader::Register(new Client());
 

--- a/src/Components/Loader.hpp
+++ b/src/Components/Loader.hpp
@@ -132,6 +132,7 @@ namespace Components
 #include "Modules/SoundMutexFix.hpp"
 #include "Modules/Chat.hpp"
 #include "Modules/TextRenderer.hpp"
+#include "Modules/Movement.hpp"
 
 #include "Modules/Gamepad.hpp"
 #include "Modules/Client.hpp"

--- a/src/Components/Modules/Dvar.cpp
+++ b/src/Components/Modules/Dvar.cpp
@@ -299,6 +299,9 @@ namespace Components
 		// Uncheat ui_debugMode
 		Utils::Hook::Xor<BYTE>(0x6312DE, Game::dvar_flag::DVAR_FLAG_CHEAT);
 
+		// Remove unknown flag (to prevent unknown behaviour)
+		Utils::Hook::Xor<BYTE>(0x448B42, Game::dvar_flag::DVAR_FLAG_UNKNOWN80);
+
 		// Hook dvar 'name' registration
 		Utils::Hook(0x40531C, Dvar::RegisterName, HOOK_CALL).install()->quick();
 

--- a/src/Components/Modules/Dvar.cpp
+++ b/src/Components/Modules/Dvar.cpp
@@ -299,9 +299,6 @@ namespace Components
 		// Uncheat ui_debugMode
 		Utils::Hook::Xor<BYTE>(0x6312DE, Game::dvar_flag::DVAR_FLAG_CHEAT);
 
-		// Remove unknown flag from player_lastStandCrawlSpeedScale (prevent unknown behaviour)
-		Utils::Hook::Xor<BYTE>(0x448B42, Game::dvar_flag::DVAR_FLAG_UNKNOWN80);
-
 		// Hook dvar 'name' registration
 		Utils::Hook(0x40531C, Dvar::RegisterName, HOOK_CALL).install()->quick();
 

--- a/src/Components/Modules/Dvar.cpp
+++ b/src/Components/Modules/Dvar.cpp
@@ -299,7 +299,7 @@ namespace Components
 		// Uncheat ui_debugMode
 		Utils::Hook::Xor<BYTE>(0x6312DE, Game::dvar_flag::DVAR_FLAG_CHEAT);
 
-		// Remove unknown flag (to prevent unknown behaviour)
+		// Remove unknown flag (prevent unknown behaviour)
 		Utils::Hook::Xor<BYTE>(0x448B42, Game::dvar_flag::DVAR_FLAG_UNKNOWN80);
 
 		// Hook dvar 'name' registration

--- a/src/Components/Modules/Dvar.cpp
+++ b/src/Components/Modules/Dvar.cpp
@@ -299,7 +299,7 @@ namespace Components
 		// Uncheat ui_debugMode
 		Utils::Hook::Xor<BYTE>(0x6312DE, Game::dvar_flag::DVAR_FLAG_CHEAT);
 
-		// Remove unknown flag (prevent unknown behaviour)
+		// Remove unknown flag from player_lastStandCrawlSpeedScale (prevent unknown behaviour)
 		Utils::Hook::Xor<BYTE>(0x448B42, Game::dvar_flag::DVAR_FLAG_UNKNOWN80);
 
 		// Hook dvar 'name' registration

--- a/src/Components/Modules/Movement.cpp
+++ b/src/Components/Modules/Movement.cpp
@@ -124,10 +124,10 @@ namespace Components
         }
     }
 
-    Game::dvar_t* Movement::Dvar_RegisterLastStandSpeedScale(const char* name, float defaultVal, float min, float max, int, const char*)
+    Game::dvar_t* Movement::Dvar_RegisterLastStandSpeedScale(const char* name, float defaultVal, float min, float max, int, const char* desc)
     {
         Movement::PlayerLastStandCrawlSpeedScale = Dvar::Register<float>(name, defaultVal,
-            min, max, Game::DVAR_FLAG_CHEAT | Game::DVAR_FLAG_REPLICATED, "TEST DESC");
+            min, max, Game::DVAR_FLAG_CHEAT | Game::DVAR_FLAG_REPLICATED, desc);
 
         return Movement::PlayerLastStandCrawlSpeedScale.get<Game::dvar_t*>();
     }

--- a/src/Components/Modules/Movement.cpp
+++ b/src/Components/Modules/Movement.cpp
@@ -1,0 +1,151 @@
+#include "STDInclude.hpp"
+
+namespace Components
+{
+    Dvar::Var Movement::PlayerDuckedSpeedScale;
+    Dvar::Var Movement::PlayerLastStandCrawlSpeedScale;
+    Dvar::Var Movement::PlayerProneSpeedScale;
+
+    int Movement::PMGetEffectiveStance(Game::playerState_s* ps)
+    {
+        auto heightTarget = ps->viewHeightTarget;
+
+        if (heightTarget == 0x16)
+            return Game::PM_EFF_STANCE_LASTSTANDCRAWL;
+
+        if (heightTarget == 0x28)
+            return Game::PM_EFF_STANCE_DUCKED;
+
+        if (heightTarget == 0xB)
+            return Game::PM_EFF_STANCE_PRONE;
+
+        return Game::PM_EFF_STANCE_DEFAULT;
+    }
+
+    float Movement::PMCmdScaleForStance(Game::pmove_s* move)
+    {
+        auto* playerState = move->ps;
+        float scale;
+
+        if (playerState->viewHeightLerpTime != 0 && playerState->viewHeightLerpTarget == 0xB)
+        {
+            scale = move->cmd.serverTime - playerState->viewHeightLerpTime / 400.0f;
+
+            if (0.0f <= scale)
+            {
+                auto flags = 0;
+
+                if (scale < 1.0f)
+                {
+                    flags |= 1 << 8;
+                }
+
+                if (scale == 1.0f)
+                {
+                    flags |= 1 << 14;
+                }
+
+                if (flags == 0)
+                {
+                    scale = 1.0f;
+                    return scale * 0.15f + (1.0f - scale) * 0.65f;
+                }
+
+                if (scale != 0.0f)
+                {
+                    return scale * 0.15f + (1.0f - scale) * 0.65f;
+                }
+            }
+        }
+
+        if ((playerState->viewHeightLerpTime != 0 && playerState->viewHeightLerpTarget == 0x28) &&
+            playerState->viewHeightLerpDown == 0)
+        {
+            scale = 400.0f / move->cmd.serverTime - playerState->viewHeightLerpTime;
+
+            if (0.0f <= scale)
+            {
+                auto flags = 0;
+
+                if (scale < 1.0f)
+                {
+                    flags |= 1 << 8;
+                }
+
+                if (scale == 1.0f)
+                {
+                    flags |= 1 << 14;
+                }
+
+                if (flags == 0)
+                {
+                    scale = 1.0f;
+                }
+                else if (scale != 0.0f)
+                {
+                    return scale * 0.65f + (1.0f - scale) * 0.15f;
+                }
+            }
+        }
+
+        scale = 1.0f;
+        auto stance = Movement::PMGetEffectiveStance(playerState);
+
+        if (stance == Game::PM_EFF_STANCE_PRONE)
+        {
+            scale = Movement::PlayerProneSpeedScale.get<float>();
+        }
+
+        else if (stance == Game::PM_EFF_STANCE_DUCKED)
+        {
+            scale = Movement::PlayerDuckedSpeedScale.get<float>();
+        }
+
+        else if (stance == Game::PM_EFF_STANCE_LASTSTANDCRAWL)
+        {
+            scale = Movement::PlayerLastStandCrawlSpeedScale.get<float>();
+        }
+
+        return scale;
+    }
+
+    __declspec(naked) void Movement::PMCmdScaleForStanceStub()
+    {
+        __asm
+        {
+            pushad
+
+            push edx
+            call Movement::PMCmdScaleForStance
+            add esp, 4
+
+            popad
+            ret
+        }
+    }
+
+    Movement::Movement()
+    {
+        Dvar::OnInit([]
+        {
+            Movement::PlayerDuckedSpeedScale = Dvar::Register<float>("player_duckedSpeedScale",
+                0.65f, 0.0f, 5.0f, Game::DVAR_FLAG_CHEAT | Game::DVAR_FLAG_REPLICATED,
+                "The scale applied to the player speed when ducking");
+
+            Movement::PlayerLastStandCrawlSpeedScale = Dvar::Register<float>("player_lastStandCrawlSpeedScale",
+                0.2f, 0.0f, 5.0f, Game::DVAR_FLAG_CHEAT | Game::DVAR_FLAG_REPLICATED,
+                "The scale applied to the player speed when crawling in last stand");
+
+            Movement::PlayerProneSpeedScale = Dvar::Register<float>("player_proneSpeedScale",
+                0.15f, 0.0f, 5.0f, Game::DVAR_FLAG_CHEAT | Game::DVAR_FLAG_REPLICATED,
+                "The scale applied to the player speed when crawling");
+        });
+
+        Utils::Hook(0x572F34, Movement::PMCmdScaleForStanceStub, HOOK_CALL).install()->quick();
+        Utils::Hook(0x57395F, Movement::PMCmdScaleForStanceStub, HOOK_CALL).install()->quick();
+    }
+
+    Movement::~Movement()
+    {
+    }
+}

--- a/src/Components/Modules/Movement.hpp
+++ b/src/Components/Modules/Movement.hpp
@@ -16,5 +16,7 @@ namespace Components
         static int PMGetEffectiveStance(Game::playerState_s* ps);
         static float PMCmdScaleForStance(Game::pmove_s* move);
         static void PMCmdScaleForStanceStub();
+
+        static Game::dvar_t* Dvar_RegisterLastStandSpeedScale(const char* name, float defaultVal, float min, float max, int flags, const char* desc);
     };
 }

--- a/src/Components/Modules/Movement.hpp
+++ b/src/Components/Modules/Movement.hpp
@@ -1,0 +1,20 @@
+#pragma once
+
+namespace Components
+{
+    class Movement : public Component
+    {
+    public:
+        Movement();
+        ~Movement();
+
+    private:
+        static Dvar::Var PlayerDuckedSpeedScale;
+        static Dvar::Var PlayerLastStandCrawlSpeedScale;
+        static Dvar::Var PlayerProneSpeedScale;
+
+        static int PMGetEffectiveStance(Game::playerState_s* ps);
+        static float PMCmdScaleForStance(Game::pmove_s* move);
+        static void PMCmdScaleForStanceStub();
+    };
+}

--- a/src/Game/Structs.hpp
+++ b/src/Game/Structs.hpp
@@ -109,7 +109,7 @@ namespace Game
 		IMG_CATEGORY_WATER = 0x5,
 		IMG_CATEGORY_RENDERTARGET = 0x6,
 		IMG_CATEGORY_TEMP = 0x7,
-	} ;
+	};
 
 	enum buttons_t
 	{

--- a/src/Game/Structs.hpp
+++ b/src/Game/Structs.hpp
@@ -6876,6 +6876,37 @@ namespace Game
 		const char* args[9];
 	};
 
+	struct pmove_s
+	{
+		playerState_s* ps;
+		usercmd_s cmd;
+		usercmd_s oldcmd;
+		int tracemask;
+		int numtouch;
+		int touchents[32];
+		char __pad0[24];
+		float xyspeed;
+		int proneChange;
+		float maxSprintTimeMultiplier;
+		bool mantleStarted;
+		float mantleEndPos[3];
+		int mantleDuration;
+		int viewChangeTime;
+		float viewChange;
+		float fTorsoPitch;
+		float fWaistPitch;
+		unsigned char handler;
+	};
+
+	enum EffectiveStance
+	{
+		PM_EFF_STANCE_DEFAULT = 0,
+		PM_EFF_STANCE_PRONE = 1,
+		PM_EFF_STANCE_DUCKED = 2,
+		PM_EFF_STANCE_LASTSTANDCRAWL = 3,
+		PM_EFF_STANCE_COUNT = 4
+	};
+
 #pragma endregion
 
 #ifndef IDA


### PR DESCRIPTION
- This PR adds two new Dvars. The player_lastStandCrawlSpeedScale Dvar was already present in the game for debugging purposes. I originally wrote this code for IW5 and since the folks at pluto liked the idea I think it will be part of their client in some next future release. I ported the code to IW4 as well because I think this kind of customization can be beneficial to the client. I thoroughly tested the code on IW5 and I briefly tested it on IW4 because the code is identical.

- The new Dvars will affect how fast the player moves when he is in the prone stance, ducked stance or in the last stand stance. A single Dvar only affects the speed of the player when he is in that specific stance. For example, the player walking speed will be unaffected by changes to these Dvars. Changing the value of player_lastStandCrawlSpeedScale will not affect the player speed when he is prone (vice versa with changes to player_proneSpeedScale).

- I reversed PM_CmdScaleForStance and I made sure that it practically does the same thing as the original game function so that it doesn't break normal game behaviour. Instead of returning hard-coded 0.65f and 0.15f values for ducked and prone stance, it will return the current value of the corresponding Dvars.

- Rekitnator helped me re-write some code spat out by the disassembler that I could not make sense of.

# Note on the Dvar flag
I hook Dvar_RegisterFloat for the Dvar `player_lastStandCrawlSpeedScale` instead of manually setting the flags in memory. This is usually how Dvars are overwritten on s1x/iw6x. This allows me to get the Dvar pointer needed in the Movement module and to change the flags. I only set `DVAR_FLAG_REPLICATED` and `DVAR_FLAG_CHEAT` because I don't know what `DVAR_FLAG_UNKNOWN80` does. I think it is okay to not set the 0x80 flag because the Dvar is only read from in my hook (or that original game function) and is only supposed to be changed via a game script or through the console. That is why the cheat flag is needed. So yeah I don't see why I should leave the 0x80 flag because the purpose of this PR is to allow server owners to change the value of `player_lastStandCrawlSpeedScale`. It should not have any undocumented behaviour. If the flag ever gets documented so we know what it does then we can add it back to the Dvar if it does make sense to do so.