### PR TITLE
[QuickPatch] Quick Refactor

### DIFF
--- a/src/Components/Modules/QuickPatch.cpp
+++ b/src/Components/Modules/QuickPatch.cpp
@@ -269,7 +269,7 @@ namespace Components
 
 	Game::dvar_t* QuickPatch::Dvar_RegisterAspectRatioDvar(const char* name, char**, int defaultVal, int flags, const char* description)
 	{
-		static char* r_aspectRatioEnum[] =
+		static const char* r_aspectRatioEnum[] =
 		{
 			"auto",
 			"standard",

--- a/src/Components/Modules/QuickPatch.hpp
+++ b/src/Components/Modules/QuickPatch.hpp
@@ -28,13 +28,13 @@ namespace Components
 
 		static void JavelinResetHookStub();
 
-		static bool InvalidNameCheck(char *dest, char *source, int size);
+		static bool InvalidNameCheck(char* dest, const char* source, int size);
 		static void InvalidNameStub();
 
 		static Game::dvar_t* sv_enableBounces;
 		static void BounceStub();
 
-		static Game::dvar_t* r_customAspectRatio;
+		static Dvar::Var r_customAspectRatio;
 		static Game::dvar_t* Dvar_RegisterAspectRatioDvar(const char* name, char** enumValues, int defaultVal, int flags, const char* description);
 		static void SetAspectRatioStub();
 		static void SetAspectRatio();

--- a/src/Game/Functions.hpp
+++ b/src/Game/Functions.hpp
@@ -247,7 +247,7 @@ namespace Game
 	typedef dvar_t* (__cdecl * Dvar_RegisterInt_t)(const char* name, int defaultVal, int min, int max, int flags, const char* description);
 	extern Dvar_RegisterInt_t Dvar_RegisterInt;
 
-	typedef dvar_t* (__cdecl * Dvar_RegisterEnum_t)(const char* name, char** enumValues, int defaultVal, int flags, const char* description);
+	typedef dvar_t* (__cdecl * Dvar_RegisterEnum_t)(const char* name, const char** enumValues, int defaultVal, int flags, const char* description);
 	extern Dvar_RegisterEnum_t Dvar_RegisterEnum;
 
 	typedef dvar_t* (__cdecl * Dvar_RegisterString_t)(const char* name, const char* defaultVal, int, const char*);


### PR DESCRIPTION
In light of a recent pull request, it came to my attention that some things were done incorrectly in the QuickPatch module.
This pr should be beneficial because:
- A vector is no longer being allocated when registering an enum dvar
- Added comments to InvalidNameCheckStub
- Replace the explicit call to strncpy with a call to actual game function. It was argued before that it is the best approach. (https://github.com/XLabsProject/iw4x-client/pull/92#discussion_r663989104).
- Proper use of const in InvalidNameCheck
- Use the dvar class wrapper when appropriate 