### PR TITLE
[Script] Add ReplaceFunc Game Script Function

### DIFF
--- a/src/Components/Modules/Bots.cpp
+++ b/src/Components/Modules/Bots.cpp
@@ -160,7 +160,7 @@ namespace Components
 	{
 		Script::AddFunction("SetPing", [](Game::scr_entref_t id) // gsc: self SetPing(<int>)
 		{
-			if (Game::Scr_GetNumParam() != 1 || Game::Scr_GetType(0) != Game::VAR_INTEGER)
+			if (Game::Scr_GetNumParam() != 1u || Game::Scr_GetType(0) != Game::VAR_INTEGER)
 			{
 				Game::Scr_Error("^1SetPing: Needs one integer parameter!\n");
 				return;
@@ -250,7 +250,7 @@ namespace Components
 
 		Script::AddFunction("botWeapon", [](Game::scr_entref_t id) // Usage: <bot> botWeapon(<str>);
 		{
-			if (Game::Scr_GetNumParam() != 1 || Game::Scr_GetType(0) != Game::VAR_STRING)
+			if (Game::Scr_GetNumParam() != 1u || Game::Scr_GetType(0) != Game::VAR_STRING)
 			{
 				Game::Scr_Error("^1botWeapon: Needs one string parameter!\n");
 				return;
@@ -293,7 +293,7 @@ namespace Components
 
 		Script::AddFunction("botAction", [](Game::scr_entref_t id) // Usage: <bot> botAction(<str action>);
 		{
-			if (Game::Scr_GetNumParam() != 1 || Game::Scr_GetType(0) != Game::VAR_STRING)
+			if (Game::Scr_GetNumParam() != 1u || Game::Scr_GetType(0) != Game::VAR_STRING)
 			{
 				Game::Scr_Error("^1botAction: Needs one string parameter!\n");
 				return;
@@ -346,7 +346,7 @@ namespace Components
 
 		Script::AddFunction("botMovement", [](Game::scr_entref_t id) // Usage: <bot> botMovement(<int>, <int>);
 		{
-			if (Game::Scr_GetNumParam() != 2 || Game::Scr_GetType(0) != Game::VAR_INTEGER || Game::Scr_GetType(1) != Game::VAR_INTEGER)
+			if (Game::Scr_GetNumParam() != 2u || Game::Scr_GetType(0) != Game::VAR_INTEGER || Game::Scr_GetType(1) != Game::VAR_INTEGER)
 			{
 				Game::Scr_Error("^1botMovement: Needs two integer parameters!\n");
 				return;

--- a/src/Components/Modules/Download.cpp
+++ b/src/Components/Modules/Download.cpp
@@ -967,7 +967,7 @@ namespace Components
 		Script::AddFunction("httpGet", [](Game::scr_entref_t)
 		{
 			if (!Dedicated::IsEnabled() && !Flags::HasFlag("scriptablehttp")) return;
-			if (Game::Scr_GetNumParam() < 1) return;
+			if (Game::Scr_GetNumParam() < 1u) return;
 
 			std::string url = Game::Scr_GetString(0);
 			unsigned int object = Game::AllocObject();
@@ -981,7 +981,7 @@ namespace Components
 		Script::AddFunction("httpCancel", [](Game::scr_entref_t)
 		{
 			if (!Dedicated::IsEnabled() && !Flags::HasFlag("scriptablehttp")) return;
-			if (Game::Scr_GetNumParam() < 1) return;
+			if (Game::Scr_GetNumParam() < 1u) return;
 
 			unsigned int object = Game::Scr_GetObject(0);
 			for (auto& download : Download::ScriptDownloads)

--- a/src/Components/Modules/Script.cpp
+++ b/src/Components/Modules/Script.cpp
@@ -384,9 +384,9 @@ namespace Components
 		Utils::Hook::Call<void(int)>(0x421EE0)(num);
 	}
 
-	int Script::SetExpFogStub()
+	unsigned int Script::SetExpFogStub()
 	{
-		if (Game::Scr_GetNumParam() == 6)
+		if (Game::Scr_GetNumParam() == 6u)
 		{
 			std::memmove(&Game::scriptContainer->stack[-4], &Game::scriptContainer->stack[-5], sizeof(Game::VariableValue) * 6);
 			Game::scriptContainer->stack += 1;
@@ -408,7 +408,7 @@ namespace Components
 	{
 		if (Script::ReplacedFunctions.find(pos) != Script::ReplacedFunctions.end())
 		{
-			Script::ReplacedPos = Script::ReplacedFunctions[pos];;
+			Script::ReplacedPos = Script::ReplacedFunctions[pos];
 		}
 	}
 
@@ -487,7 +487,7 @@ namespace Components
 	{
 		Script::AddFunction("ReplaceFunc", [](Game::scr_entref_t) // gsc: ReplaceFunc(<function>,<function>)
 		{
-			if (Game::Scr_GetNumParam() != 2)
+			if (Game::Scr_GetNumParam() != 2u)
 			{
 				Game::Scr_Error("^1ReplaceFunc: Needs two parameters!\n");
 				return;
@@ -525,7 +525,7 @@ namespace Components
 		// Print to console, even without being in 'developer 1'.
 		Script::AddFunction("PrintConsole", [](Game::scr_entref_t) // gsc: PrintConsole(<string>)
 		{
-			if (Game::Scr_GetNumParam() != 1 || Game::Scr_GetType(0) != Game::VAR_STRING)
+			if (Game::Scr_GetNumParam() != 1u || Game::Scr_GetType(0) != Game::VAR_STRING)
 			{
 				Game::Scr_Error("^1PrintConsole: Needs one string parameter!\n");
 				return;
@@ -539,7 +539,7 @@ namespace Components
 		// Executes command to the console
 		Script::AddFunction("Exec", [](Game::scr_entref_t) // gsc: Exec(<string>)
 		{
-			if (Game::Scr_GetNumParam() != 1 || Game::Scr_GetType(0) != Game::VAR_STRING)
+			if (Game::Scr_GetNumParam() != 1u || Game::Scr_GetType(0) != Game::VAR_STRING)
 			{
 				Game::Scr_Error("^1Exec: Needs one string parameter!\n");
 				return;
@@ -554,7 +554,7 @@ namespace Components
 		// Script Storage Funcs
 		Script::AddFunction("StorageSet", [](Game::scr_entref_t) // gsc: StorageSet(<str key>, <str data>);
 		{
-			if (Game::Scr_GetNumParam() != 2 || Game::Scr_GetType(0) != Game::VAR_STRING || Game::Scr_GetType(1) != Game::VAR_STRING)
+			if (Game::Scr_GetNumParam() != 2u || Game::Scr_GetType(0) != Game::VAR_STRING || Game::Scr_GetType(1) != Game::VAR_STRING)
 			{
 				Game::Scr_Error("^1StorageSet: Needs two string parameters!\n");
 				return;
@@ -568,7 +568,7 @@ namespace Components
 
 		Script::AddFunction("StorageRemove", [](Game::scr_entref_t) // gsc: StorageRemove(<str key>);
 		{
-			if (Game::Scr_GetNumParam() != 1 || Game::Scr_GetType(0) != Game::VAR_STRING)
+			if (Game::Scr_GetNumParam() != 1u || Game::Scr_GetType(0) != Game::VAR_STRING)
 			{
 				Game::Scr_Error("^1StorageRemove: Needs one string parameter!\n");
 				return;
@@ -587,7 +587,7 @@ namespace Components
 
 		Script::AddFunction("StorageGet", [](Game::scr_entref_t) // gsc: StorageGet(<str key>);
 		{
-			if (Game::Scr_GetNumParam() != 1 || Game::Scr_GetType(0) != Game::VAR_STRING)
+			if (Game::Scr_GetNumParam() != 1u || Game::Scr_GetType(0) != Game::VAR_STRING)
 			{
 				Game::Scr_Error("^1StorageGet: Needs one string parameter!\n");
 				return;
@@ -607,7 +607,7 @@ namespace Components
 
 		Script::AddFunction("StorageHas", [](Game::scr_entref_t) // gsc: StorageHas(<str key>);
 		{
-			if (Game::Scr_GetNumParam() != 1 || Game::Scr_GetType(0) != Game::VAR_STRING)
+			if (Game::Scr_GetNumParam() != 1u || Game::Scr_GetType(0) != Game::VAR_STRING)
 			{
 				Game::Scr_Error("^1StorageHas: Needs one string parameter!\n");
 				return;

--- a/src/Components/Modules/Script.cpp
+++ b/src/Components/Modules/Script.cpp
@@ -399,7 +399,7 @@ namespace Components
 		return Game::Scr_GetNumParam();
 	}
 
-	const char* Script::GetCodePosForParam(unsigned int index)
+	const char* Script::GetCodePosForParam(int index)
 	{
 		if (index >= Game::scrVmPub->outparamcount)
 		{
@@ -407,7 +407,7 @@ namespace Components
 			return "";
 		}
 
-		const auto value = &Game::scrVmPub->top[0 - index];
+		const auto value = &Game::scrVmPub->top[-index];
 
 		if (value->type != Game::VAR_FUNCTION)
 		{

--- a/src/Components/Modules/Script.cpp
+++ b/src/Components/Modules/Script.cpp
@@ -391,7 +391,7 @@ namespace Components
 			std::memmove(&Game::scrVmPub->top[-4], &Game::scrVmPub->top[-5], sizeof(Game::VariableValue) * 6);
 			Game::scrVmPub->top += 1;
 			Game::scrVmPub->top[-6].type = Game::VAR_FLOAT;
-			Game::scrVmPub->top[-6].u.floatValue = 0;
+			Game::scrVmPub->top[-6].u.floatValue = 0.0f;
 
 			++Game::scrVmPub->outparamcount;
 		}

--- a/src/Components/Modules/Script.cpp
+++ b/src/Components/Modules/Script.cpp
@@ -512,12 +512,6 @@ namespace Components
 				return;
 			}
 
-			if (Game::Scr_GetType(0) != Game::VAR_FUNCTION || Game::Scr_GetType(1) != Game::VAR_FUNCTION)
-			{
-				Game::Scr_Error("^1ReplaceFunc: Needs function pointers as parameters!\n");
-				return;
-			}
-
 			const auto what = Script::GetCodePosForParam(0);
 			const auto with = Script::GetCodePosForParam(1);
 

--- a/src/Components/Modules/Script.cpp
+++ b/src/Components/Modules/Script.cpp
@@ -401,7 +401,7 @@ namespace Components
 
 	const char* Script::GetCodePosForParam(int index)
 	{
-		if (index >= Game::scrVmPub->outparamcount)
+		if (static_cast<unsigned int>(index) >= Game::scrVmPub->outparamcount)
 		{
 			Game::Scr_Error("^1GetCodePosForParam: Index is out of range!\n");
 			return "";

--- a/src/Components/Modules/Script.cpp
+++ b/src/Components/Modules/Script.cpp
@@ -414,7 +414,6 @@ namespace Components
 
 	void Script::SetReplacedPos(const char* what, const char* with)
 	{
-		// Warn if the function was already detoured
 		if (Script::ReplacedFunctions.find(what) != Script::ReplacedFunctions.end())
 		{
 			Logger::Print("Warning: a function was already detoured by a script\n");
@@ -485,7 +484,7 @@ namespace Components
 
 	void Script::AddFunctions()
 	{
-		Script::AddFunction("ReplaceFunc", [](Game::scr_entref_t) // gsc: ReplaceFunc(<function>,<function>)
+		Script::AddFunction("ReplaceFunc", [](Game::scr_entref_t) // gsc: ReplaceFunc(<function>, <function>)
 		{
 			if (Game::Scr_GetNumParam() != 2u)
 			{

--- a/src/Components/Modules/Script.hpp
+++ b/src/Components/Modules/Script.hpp
@@ -72,7 +72,7 @@ namespace Components
 
 		static unsigned int SetExpFogStub();
 
-		static const char* GetCodePosForParam(unsigned int index);
+		static const char* GetCodePosForParam(int index);
 		static void GetReplacedPos(const char* pos);
 		static void SetReplacedPos(const char* what, const char* with);
 		static void VMExecuteInternalStub();

--- a/src/Components/Modules/Script.hpp
+++ b/src/Components/Modules/Script.hpp
@@ -72,7 +72,7 @@ namespace Components
 
 		static unsigned int SetExpFogStub();
 
-		static const char* GetCodePosForParam(int index);
+		static const char* GetCodePosForParam(unsigned int index);
 		static void GetReplacedPos(const char* pos);
 		static void SetReplacedPos(const char* what, const char* with);
 		static void VMExecuteInternalStub();

--- a/src/Components/Modules/Script.hpp
+++ b/src/Components/Modules/Script.hpp
@@ -40,6 +40,8 @@ namespace Components
 		static unsigned short FunctionName;
 		static std::unordered_map<std::string, std::string> ScriptStorage;
 		static std::unordered_map<int, std::string> ScriptBaseProgramNum;
+		static std::unordered_map<const char*, const char*> ReplacedFunctions;
+		static const char* ReplacedPos;
 		static int LastFrameTime;
 
 		static Utils::Signal<Scheduler::Callback> VMShutdownSignal;
@@ -69,6 +71,11 @@ namespace Components
 		static void Scr_PrintPrevCodePos(int);
 
 		static int SetExpFogStub();
+
+		static const char* GetCodePosForParam(int index);
+		static void GetReplacedPos(const char* pos);
+		static void SetReplacedPos(const char* what, const char* with);
+		static void VMExecuteInternalStub();
 
 		static void AddFunctions();
 	};

--- a/src/Components/Modules/Script.hpp
+++ b/src/Components/Modules/Script.hpp
@@ -70,7 +70,7 @@ namespace Components
 		static void Scr_PrintPrevCodePosStub();
 		static void Scr_PrintPrevCodePos(int);
 
-		static int SetExpFogStub();
+		static unsigned int SetExpFogStub();
 
 		static const char* GetCodePosForParam(int index);
 		static void GetReplacedPos(const char* pos);

--- a/src/Components/Modules/Slowmotion.cpp
+++ b/src/Components/Modules/Slowmotion.cpp
@@ -38,12 +38,12 @@ namespace Components
 		float start = Game::Scr_GetFloat(0);
 		float end = 1.0f;
 
-		if (Game::Scr_GetNumParam() >= 2)
+		if (Game::Scr_GetNumParam() >= 2u)
 		{
 			end = Game::Scr_GetFloat(1);
 		}
 
-		if (Game::Scr_GetNumParam() >= 3)
+		if (Game::Scr_GetNumParam() >= 3u)
 		{
 			duration = static_cast<int>(Game::Scr_GetFloat(2) * 1000.0);
 		}

--- a/src/Game/Functions.cpp
+++ b/src/Game/Functions.cpp
@@ -460,7 +460,7 @@ namespace Game
 	XZone* g_zones = reinterpret_cast<XZone*>(0x14C0F80);
 	unsigned short* db_hashTable = reinterpret_cast<unsigned short*>(0x12412B0);
 
-	ScriptContainer* scriptContainer = reinterpret_cast<ScriptContainer*>(0x2040D00);
+	scrVmPub_t* scrVmPub = reinterpret_cast<scrVmPub_t*>(0x2040CF0);
 
 	clientstate_t* clcState = reinterpret_cast<clientstate_t*>(0xB2C540);
 

--- a/src/Game/Functions.hpp
+++ b/src/Game/Functions.hpp
@@ -968,7 +968,7 @@ namespace Game
 	extern XZone* g_zones;
 	extern unsigned short* db_hashTable;
 
-	extern ScriptContainer* scriptContainer;
+	extern scrVmPub_t* scrVmPub;
 
 	extern clientstate_t* clcState;
 

--- a/src/Game/Functions.hpp
+++ b/src/Game/Functions.hpp
@@ -660,7 +660,7 @@ namespace Game
 	typedef unsigned int(__cdecl * Scr_GetObject_t)(int);
 	extern Scr_GetObject_t Scr_GetObject;
 
-	typedef int(__cdecl * Scr_GetNumParam_t)();
+	typedef unsigned int(__cdecl * Scr_GetNumParam_t)();
 	extern Scr_GetNumParam_t Scr_GetNumParam;
 
 	typedef int(__cdecl * Scr_GetFunctionHandle_t)(const char*, const char*);
@@ -687,7 +687,7 @@ namespace Game
 	typedef bool(__cdecl * Scr_IsSystemActive_t)();
 	extern Scr_IsSystemActive_t Scr_IsSystemActive;
 
-	typedef int(__cdecl* Scr_GetType_t)(int);
+	typedef int(__cdecl* Scr_GetType_t)(unsigned int);
 	extern Scr_GetType_t Scr_GetType;
 
 	typedef void(__cdecl* Scr_Error_t)(const char*);

--- a/src/Game/Structs.hpp
+++ b/src/Game/Structs.hpp
@@ -4889,15 +4889,35 @@ namespace Game
 		VariableType type;
 	};
 
-	struct ScriptContainer
+	struct function_stack_t
 	{
-		VariableValue* stack;
-		char unk1;
-		char unk2;
-		char unk3;
-		char pad;
-		DWORD unk4;
-		int numParam;
+		const char* pos;
+		unsigned int localId;
+		unsigned int localVarCount;
+		VariableValue* top;
+		VariableValue* startTop;
+	};
+
+	struct function_frame_t
+	{
+		function_stack_t fs;
+		int topType;
+	};
+
+	struct scrVmPub_t
+	{
+		unsigned int* localVars;
+		VariableValue* maxStack;
+		int function_count;
+		function_frame_t* function_frame;
+		VariableValue* top;
+		bool debugCode;
+		bool abort_on_error;
+		bool terminal_error;
+		unsigned int inparamcount;
+		unsigned int outparamcount;
+		function_frame_t function_frame_start[32];
+		VariableValue stack[2048];
 	};
 
 	enum UILocalVarType

--- a/src/Game/Structs.hpp
+++ b/src/Game/Structs.hpp
@@ -4886,7 +4886,7 @@ namespace Game
 	struct VariableValue
 	{
 		VariableUnion u;
-		int type;
+		VariableType type;
 	};
 
 	struct ScriptContainer


### PR DESCRIPTION
- Corrected function signature for `Scr_GetNumParam` and `Scr_GetType`, which means I fixed signed/unsigned mismatch.
- If a function gets detoured more than once a warning is printed. I don't know how to make the warning message more specific at the moment. I honestly would prefer if instead of a warning an error is thrown by `Scr_Error` or detouring more than once the same function was not permitted but I kept it like `Evan ☆/Eve` suggested on discord. Let me know if that's okay.
Code was tested by hooking a few functions, it works as intended. 

# Example(s)
```
init() // Or main()
{
	replaceFunc( maps\mp\perks\_perkfunctions::GlowStickDamageListener, ::GlowStickDamageListenerHook );
}
GlowStickDamageListenerHook( owner )
{
	// Write your own code here
}
```

# Credits
 * [fedddddd](https://github.com/fedddddd) - He wrote the code for IW5. I took a lot from his code.