### PR TITLE
[Dedicated] Add random map rotation

### DIFF
--- a/src/Components/Modules/Dedicated.cpp
+++ b/src/Components/Modules/Dedicated.cpp
@@ -3,6 +3,7 @@
 namespace Components
 {
 	SteamID Dedicated::PlayerGuids[18][2];
+	Dvar::Var Dedicated::SVRandomMapRotation;
 
 	bool Dedicated::IsEnabled()
 	{
@@ -119,6 +120,41 @@ namespace Components
 		Game::Com_Error(code, message);
 	}
 
+	void Dedicated::RandomizeMapRotation()
+	{
+		auto rotation = Dvar::Var("sv_mapRotation").get<std::string>();
+
+		const auto tokens = Utils::String::Explode(rotation, ' ');
+		std::vector<std::pair<std::string, std::string>> mapRotationPair;
+
+		for (auto i = 0u; i < (tokens.size() - 1); i += 2)
+		{
+			if (i + 1 >= tokens.size()) break;
+
+			const std::string key = tokens[i];
+			const std::string value = tokens[i + 1];
+			mapRotationPair.push_back(std::make_pair(key, value));
+		}
+
+		const auto seed = Utils::Cryptography::Rand::GenerateInt();
+		std::shuffle(std::begin(mapRotationPair), std::end(mapRotationPair), std::default_random_engine(seed));
+
+		// Rebuild map rotation using the randomized key/values
+		rotation.clear();
+		for (auto j = 0u; j < mapRotationPair.size(); j++)
+		{
+			std::pair<std::string, std::string> pair = mapRotationPair[j];
+			rotation.append(pair.first);
+			rotation.append(" ");
+			rotation.append(pair.second);
+
+			if (j != mapRotationPair.size() - 1)
+				rotation.append(" ");
+		}
+
+		Dvar::Var("sv_mapRotationCurrent").set(rotation);
+	}
+
 	void Dedicated::MapRotate()
 	{
 		if (!Dedicated::IsEnabled() && Dvar::Var("sv_dontrotate").get<bool>())
@@ -134,9 +170,10 @@ namespace Components
 		}
 
 		Logger::Print("Rotating map...\n");
+		const auto mapRotation = Dvar::Var("sv_mapRotation").get<std::string>();
 
 		// if nothing, just restart
-		if (Dvar::Var("sv_mapRotation").get<std::string>().empty())
+		if (mapRotation.empty())
 		{
 			Logger::Print("No rotation defined, restarting map.\n");
 
@@ -152,14 +189,23 @@ namespace Components
 			return;
 		}
 
-		// first, check if the string contains nothing
+		// First, check if the string contains nothing
 		if (Dvar::Var("sv_mapRotationCurrent").get<std::string>().empty())
 		{
 			Logger::Print("Current map rotation has finished, reloading...\n");
-			Dvar::Var("sv_mapRotationCurrent").set(Dvar::Var("sv_mapRotation").get<const char*>());
+
+			if (Dedicated::SVRandomMapRotation.get<bool>())
+			{
+				Logger::Print("Randomizing map rotaion\n");
+				Dedicated::RandomizeMapRotation();
+			}
+			else
+			{
+				Dvar::Var("sv_mapRotationCurrent").set(mapRotation);
+			}
 		}
 
-		std::string rotation = Dvar::Var("sv_mapRotationCurrent").get<std::string>();
+		auto rotation = Dvar::Var("sv_mapRotationCurrent").get<std::string>();
 
 		auto tokens = Utils::String::Explode(rotation, ' ');
 
@@ -346,6 +392,7 @@ namespace Components
 
 				Dvar::OnInit([]()
 				{
+					Dedicated::SVRandomMapRotation = Dvar::Register<bool>("sv_randomMapRotation", false, Game::dvar_flag::DVAR_FLAG_SAVED, "Randomize map rotation when true");
 					Dvar::Register<const char*>("sv_sayName", "^7Console", Game::dvar_flag::DVAR_FLAG_NONE, "The name to pose as for 'say' commands");
 					Dvar::Register<const char*>("sv_motd", "", Game::dvar_flag::DVAR_FLAG_NONE, "A custom message of the day for servers");
 

--- a/src/Components/Modules/Dedicated.cpp
+++ b/src/Components/Modules/Dedicated.cpp
@@ -131,8 +131,8 @@ namespace Components
 		{
 			if (i + 1 >= tokens.size()) break;
 
-			const std::string key = tokens[i];
-			const std::string value = tokens[i + 1];
+			const auto& key = tokens[i];
+			const auto& value = tokens[i + 1];
 			mapRotationPair.push_back(std::make_pair(key, value));
 		}
 
@@ -143,7 +143,7 @@ namespace Components
 		rotation.clear();
 		for (auto j = 0u; j < mapRotationPair.size(); j++)
 		{
-			std::pair<std::string, std::string> pair = mapRotationPair[j];
+			const auto& pair = mapRotationPair[j];
 			rotation.append(pair.first);
 			rotation.append(" ");
 			rotation.append(pair.second);
@@ -196,7 +196,7 @@ namespace Components
 
 			if (Dedicated::SVRandomMapRotation.get<bool>())
 			{
-				Logger::Print("Randomizing map rotaion\n");
+				Logger::Print("Randomizing map rotation\n");
 				Dedicated::RandomizeMapRotation();
 			}
 			else

--- a/src/Components/Modules/Dedicated.hpp
+++ b/src/Components/Modules/Dedicated.hpp
@@ -15,6 +15,9 @@ namespace Components
 		static void Heartbeat();
 
 	private:
+		static Dvar::Var SVRandomMapRotation;
+
+		static void RandomizeMapRotation();
 		static void MapRotate();
 		static void InitDedicatedServer();
 

--- a/src/STDInclude.hpp
+++ b/src/STDInclude.hpp
@@ -42,10 +42,9 @@
 #include <algorithm>
 #include <limits>
 #include <cmath>
-
-// Experimental C++17 features
 #include <filesystem>
 #include <optional>
+#include <random>
 
 #pragma warning(pop)
 


### PR DESCRIPTION
Adds `sv_randomMapRotation` bool dvar. If set to true and `sv_mapRotationCurrent` is empty (when the server starts for the first time), the map rotation will be randomized.

So the new function will take as input key/value pairs from `sv_mapRotation` where the key is either `map` or `gametype` and the value can be the name of the map or the name for the `gametype`.
Every pair of the key/value will be shuffled, so game mode changes and the position of the maps in `sv_mapRotation` is random. I tested the code a couple of times, and at every startup of my dedicated server, the string value of the map rotation Dvar was different each time.

If merged, #105 can be closed.

# Credits
As mentioned by the issue, the idea of implementing this feature comes from CoD4x_Server, but the code itself does not. Simply put, I couldn't understand a single line of the C function they use to shuffle the map rotation, so I wrote this.