### PR TITLE
[Feature] Add options to disable elevators

### DIFF
--- a/src/Components/Loader.cpp
+++ b/src/Components/Loader.cpp
@@ -105,6 +105,7 @@ namespace Components
 		Loader::Register(new Chat());
 		Loader::Register(new TextRenderer());
 		Loader::Register(new Movement());
+		Loader::Register(new Elevators());
 
 		Loader::Register(new Client());
 

--- a/src/Components/Loader.hpp
+++ b/src/Components/Loader.hpp
@@ -133,6 +133,7 @@ namespace Components
 #include "Modules/Chat.hpp"
 #include "Modules/TextRenderer.hpp"
 #include "Modules/Movement.hpp"
+#include "Modules/Elevators.hpp"
 
 #include "Modules/Gamepad.hpp"
 #include "Modules/Client.hpp"

--- a/src/Components/Modules/Elevators.cpp
+++ b/src/Components/Modules/Elevators.cpp
@@ -1,0 +1,81 @@
+#include "STDInclude.hpp"
+
+namespace Components
+{
+	Game::dvar_t* Elevators::SV_EnableEasyElevators;
+
+	__declspec(naked) void Elevators::PM_CorrectAllSolidStub()
+	{
+		__asm
+		{
+			push ecx
+			mov ecx, Elevators::SV_EnableEasyElevators
+			cmp byte ptr [ecx + 16], 1
+			pop ecx
+
+			// Always elevate if SV_EnableEasyElevators is set to 1
+			je elevate
+
+			// Original code
+			cmp byte ptr [eax + 0x29], 0
+
+			// Original code flow
+			jz elevate
+
+			push 0x5734FF
+			retn
+
+		elevate:
+			push 0x57353D
+			retn
+		}
+	}
+
+	__declspec(naked) void Elevators::PM_CheckDuckStub()
+	{
+		__asm
+		{
+			push eax
+			mov eax, Elevators::SV_EnableEasyElevators
+			cmp byte ptr [eax + 16], 1
+			pop eax
+
+			// Always stand if SV_EnableEasyElevators is set to 1
+			je stand
+
+			// Original code
+			cmp byte ptr [esp + 0x38], 0
+
+			// Original code flow
+			jnz noStand
+
+		stand:
+
+			push 0x570ED4
+			retn
+
+		noStand:
+			push 0x570EF4
+			retn
+		}
+	}
+
+	Elevators::Elevators()
+	{
+		Dvar::OnInit([]
+		{
+			Elevators::SV_EnableEasyElevators = Game::Dvar_RegisterBool("sv_enableEasyElevators",
+				false, Game::DVAR_FLAG_CHEAT | Game::DVAR_FLAG_REPLICATED,
+				"Enable easy elevators for trickshotting");
+		});
+
+		Utils::Hook(0x5734F9, Elevators::PM_CorrectAllSolidStub, HOOK_JUMP).install()->quick();
+		Utils::Hook::Nop(0x5734FE, 1);
+
+		Utils::Hook(0x570ECD, Elevators::PM_CheckDuckStub, HOOK_JUMP).install()->quick();
+	}
+
+	Elevators::~Elevators()
+	{
+	}
+}

--- a/src/Components/Modules/Elevators.cpp
+++ b/src/Components/Modules/Elevators.cpp
@@ -3,6 +3,7 @@
 namespace Components
 {
 	Game::dvar_t* Elevators::SV_EnableEasyElevators;
+	Game::dvar_t* Elevators::SV_DisableElevators;
 
 	__declspec(naked) void Elevators::PM_CorrectAllSolidStub()
 	{
@@ -63,6 +64,39 @@ namespace Components
 		}
 	}
 
+	__declspec(naked) void Elevators::PM_GroundTraceStub()
+	{
+		__asm
+		{
+			push eax
+			mov eax, Elevators::SV_DisableElevators
+			cmp byte ptr [eax + 16], 1
+			pop eax
+
+			// Always skip PM_CorrectAllSolid if SV_DisableElevators is set to 1
+			je noElevators
+
+			// Original code
+			cmp byte ptr [esp + 0x50], 0
+			rep movsd
+			mov esi, [esp + 0x58]
+
+			// Original code flow
+			push 0x573694 
+			retn
+
+		noElevators:
+
+			// Original code
+			rep movsd
+			mov esi, [esp + 0x58]
+
+			// Jump over call to PM_CorrectAllSolid
+			push 0x5736AE
+			retn
+		}
+	}
+
 	Elevators::Elevators()
 	{
 		Dvar::OnInit([]
@@ -70,14 +104,20 @@ namespace Components
 			Elevators::SV_EnableEasyElevators = Game::Dvar_RegisterBool("sv_enableEasyElevators",
 				false, Game::DVAR_FLAG_CHEAT | Game::DVAR_FLAG_REPLICATED,
 				"Enable easy elevators for trickshotting");
+			Elevators::SV_DisableElevators = Game::Dvar_RegisterBool("sv_disableElevators",
+				false, Game::DVAR_FLAG_CHEAT | Game::DVAR_FLAG_REPLICATED,
+				"Disable elevators");
 		});
 
-		// Place hook PM_CorrectAllSolid so we may skip PM_Trace check
+		// Hook PM_CorrectAllSolid so we may skip PM_Trace check
 		Utils::Hook(0x5734F9, Elevators::PM_CorrectAllSolidStub, HOOK_JUMP).install()->quick();
 		Utils::Hook::Nop(0x5734FE, 1);
 
-		// Place hook PM_CheckDuck so we may skip PM_Trace check
+		// Hook PM_CheckDuck so we may skip PM_Trace check
 		Utils::Hook(0x570ECD, Elevators::PM_CheckDuckStub, HOOK_JUMP).install()->quick();
+
+		// Hook PM_GroundTrace so me way skip PM_CorrectAllSolid (disable elevators)
+		Utils::Hook(0x573689, Elevators::PM_GroundTraceStub, HOOK_JUMP).install()->quick();
 	}
 
 	Elevators::~Elevators()

--- a/src/Components/Modules/Elevators.cpp
+++ b/src/Components/Modules/Elevators.cpp
@@ -2,67 +2,7 @@
 
 namespace Components
 {
-	Game::dvar_t* Elevators::SV_EnableEasyElevators;
 	Game::dvar_t* Elevators::SV_DisableElevators;
-
-	__declspec(naked) void Elevators::PM_CorrectAllSolidStub()
-	{
-		__asm
-		{
-			push ecx
-			mov ecx, Elevators::SV_EnableEasyElevators
-			cmp byte ptr [ecx + 16], 1
-			pop ecx
-
-			// Always elevate if SV_EnableEasyElevators is set to 1
-			je elevate
-
-			// Original code
-			cmp byte ptr [eax + 0x29], 0
-
-			// Original code flow
-			jz elevate
-
-			// Go to conditional check for the loop
-			push 0x5734FF
-			retn
-
-		elevate:
-			// Continue with loop execution
-			push 0x57353D
-			retn
-		}
-	}
-
-	__declspec(naked) void Elevators::PM_CheckDuckStub()
-	{
-		__asm
-		{
-			push eax
-			mov eax, Elevators::SV_EnableEasyElevators
-			cmp byte ptr [eax + 16], 1
-			pop eax
-
-			// Always stand if SV_EnableEasyElevators is set to 1
-			je stand
-
-			// Original code
-			cmp byte ptr [esp + 0x38], 0
-
-			// Original code flow
-			jnz noStand
-
-		stand:
-			// Player is allowed to stand
-			push 0x570ED4
-			retn
-
-		noStand:
-			// Player will remain ducked
-			push 0x570EF4
-			retn
-		}
-	}
 
 	__declspec(naked) void Elevators::PM_GroundTraceStub()
 	{
@@ -101,20 +41,10 @@ namespace Components
 	{
 		Dvar::OnInit([]
 		{
-			Elevators::SV_EnableEasyElevators = Game::Dvar_RegisterBool("sv_enableEasyElevators",
-				false, Game::DVAR_FLAG_CHEAT | Game::DVAR_FLAG_REPLICATED,
-				"Enable easy elevators for trickshotting");
 			Elevators::SV_DisableElevators = Game::Dvar_RegisterBool("sv_disableElevators",
 				false, Game::DVAR_FLAG_CHEAT | Game::DVAR_FLAG_REPLICATED,
 				"Disable elevators");
 		});
-
-		// Hook PM_CorrectAllSolid so we may skip PM_Trace check
-		Utils::Hook(0x5734F9, Elevators::PM_CorrectAllSolidStub, HOOK_JUMP).install()->quick();
-		Utils::Hook::Nop(0x5734FE, 1);
-
-		// Hook PM_CheckDuck so we may skip PM_Trace check
-		Utils::Hook(0x570ECD, Elevators::PM_CheckDuckStub, HOOK_JUMP).install()->quick();
 
 		// Hook PM_GroundTrace so me way skip PM_CorrectAllSolid (disable elevators)
 		Utils::Hook(0x573689, Elevators::PM_GroundTraceStub, HOOK_JUMP).install()->quick();

--- a/src/Components/Modules/Elevators.cpp
+++ b/src/Components/Modules/Elevators.cpp
@@ -22,10 +22,12 @@ namespace Components
 			// Original code flow
 			jz elevate
 
+			// Go to conditional check for the loop
 			push 0x5734FF
 			retn
 
 		elevate:
+			// Continue with loop execution
 			push 0x57353D
 			retn
 		}
@@ -50,11 +52,12 @@ namespace Components
 			jnz noStand
 
 		stand:
-
+			// Player is allowed to stand
 			push 0x570ED4
 			retn
 
 		noStand:
+			// Player will remain ducked
 			push 0x570EF4
 			retn
 		}
@@ -69,9 +72,11 @@ namespace Components
 				"Enable easy elevators for trickshotting");
 		});
 
+		// Place hook PM_CorrectAllSolid so we may skip PM_Trace check
 		Utils::Hook(0x5734F9, Elevators::PM_CorrectAllSolidStub, HOOK_JUMP).install()->quick();
 		Utils::Hook::Nop(0x5734FE, 1);
 
+		// Place hook PM_CheckDuck so we may skip PM_Trace check
 		Utils::Hook(0x570ECD, Elevators::PM_CheckDuckStub, HOOK_JUMP).install()->quick();
 	}
 

--- a/src/Components/Modules/Elevators.cpp
+++ b/src/Components/Modules/Elevators.cpp
@@ -42,8 +42,7 @@ namespace Components
 		Dvar::OnInit([]
 		{
 			Elevators::SV_DisableElevators = Game::Dvar_RegisterBool("sv_disableElevators",
-				false, Game::DVAR_FLAG_CHEAT | Game::DVAR_FLAG_REPLICATED,
-				"Disable elevators");
+				false, Game::DVAR_FLAG_REPLICATED, "Disable elevators");
 		});
 
 		// Hook PM_GroundTrace so me way skip PM_CorrectAllSolid (disable elevators)

--- a/src/Components/Modules/Elevators.hpp
+++ b/src/Components/Modules/Elevators.hpp
@@ -10,8 +10,10 @@ namespace Components
 
 	private:
 		static Game::dvar_t* SV_EnableEasyElevators;
+		static Game::dvar_t* SV_DisableElevators;
 
 		static void PM_CorrectAllSolidStub();
 		static void PM_CheckDuckStub();
+		static void PM_GroundTraceStub();
 	};
 }

--- a/src/Components/Modules/Elevators.hpp
+++ b/src/Components/Modules/Elevators.hpp
@@ -1,0 +1,17 @@
+#pragma once
+
+namespace Components
+{
+	class Elevators : public Component
+	{
+	public:
+		Elevators();
+		~Elevators();
+
+	private:
+		static Game::dvar_t* SV_EnableEasyElevators;
+
+		static void PM_CorrectAllSolidStub();
+		static void PM_CheckDuckStub();
+	};
+}

--- a/src/Components/Modules/Elevators.hpp
+++ b/src/Components/Modules/Elevators.hpp
@@ -9,11 +9,8 @@ namespace Components
 		~Elevators();
 
 	private:
-		static Game::dvar_t* SV_EnableEasyElevators;
 		static Game::dvar_t* SV_DisableElevators;
 
-		static void PM_CorrectAllSolidStub();
-		static void PM_CheckDuckStub();
 		static void PM_GroundTraceStub();
 	};
 }


### PR DESCRIPTION
# About
A stub is added inside PM_GroundTrace, it will allow skipping the only call to PM_CorrectAllSolidStub (if the sv_disableElevators Dvar is set to 1) and will disable elevators. This feature should be welcomed by server owners that don't want people to glitch out of maps.

- sv_disableElevators: default to false so elevators are only disabled if it's set to 1 by the server owner. Dvar is cheat protected and replicated as it should be imo

sv_disableElevators follows the principles described here: [Research](https://xoxor4d.github.io/research/mw2-elevator/).
To recap, xoxor4d observes that skipping a call to PM_CorrectAllSolid or PM_JitterPoint in later Cods disables elevators.

# Credits
 * [xoxor4d](https://github.com/xoxor4d)
 - Matrix for general feedback