### PR TITLE
Restore setviewpos command

### DIFF
--- a/src/Components/Modules/ClientCommand.cpp
+++ b/src/Components/Modules/ClientCommand.cpp
@@ -150,7 +150,7 @@ namespace Components
 			if (params.length() < 4u || params.length() > 6u)
 			{
 				Game::SV_GameSendServerCommand(ent->s.number, 0,
-					"print \"GAME_USAGE\x15: setviewpos x y z [yaw] [pitch]\n\"");
+					Utils::String::VA("%c \"GAME_USAGE\x15: setviewpos x y z [yaw] [pitch]\n\"", 0x65));
 				return;
 			}
 

--- a/src/Components/Modules/ClientCommand.cpp
+++ b/src/Components/Modules/ClientCommand.cpp
@@ -159,12 +159,12 @@ namespace Components
 				origin[i] = std::strtof(params.get(i + 1), nullptr);
 			}
 
-			if (params.length() == 5)
+			if (params.length() >= 5u)
 			{
 				angles[1] = std::strtof(params.get(4), nullptr); // Yaw
 			}
 
-			if (params.length() == 6)
+			if (params.length() == 6u)
 			{
 				angles[0] = std::strtof(params.get(5), nullptr); // Pitch
 			}

--- a/src/Components/Modules/ClientCommand.cpp
+++ b/src/Components/Modules/ClientCommand.cpp
@@ -136,6 +136,41 @@ namespace Components
 			Game::SV_GameSendServerCommand(entNum, 0, Utils::String::VA("%c \"%s\"", 0x65,
 				(ent->flags & Game::FL_NOTARGET) ? "GAME_NOTARGETON" : "GAME_NOTARGETOFF"));
 		});
+
+		ClientCommand::Add("setviewpos", [](Game::gentity_s* ent)
+		{
+			assert(ent != nullptr);
+
+			if (!ClientCommand::CheatsOk(ent))
+				return;
+
+			Command::ServerParams params = {};
+			Game::vec3_t origin, angles{0.f, 0.f, 0.f};
+
+			if (params.length() < 4u || params.length() > 6u)
+			{
+				Game::SV_GameSendServerCommand(ent->s.number, 0,
+					"print \"GAME_USAGE\x15: setviewpos x y z [yaw] [pitch]\n\"");
+				return;
+			}
+
+			for (auto i = 0; i < 3; i++)
+			{
+				origin[i] = std::strtof(params.get(i + 1), nullptr);
+			}
+
+			if (params.length() == 5)
+			{
+				angles[1] = std::strtof(params.get(4), nullptr); // Yaw
+			}
+
+			if (params.length() == 6)
+			{
+				angles[0] = std::strtof(params.get(5), nullptr); // Pitch
+			}
+
+			Game::TeleportPlayer(ent, origin, angles);
+		});
 	}
 
 	void ClientCommand::AddScriptFunctions()

--- a/src/Components/Modules/Command.cpp
+++ b/src/Components/Modules/Command.cpp
@@ -160,52 +160,6 @@ namespace Components
 	{
 		AssertSize(Game::cmd_function_t, 24);
 
-		static int toastDurationShort = 1000;
-		static int toastDurationMedium = 2500;
-		static int toastDurationLong = 5000;
-
-		Command::Add("setviewpos", [](Command::Params* params)
-		{
-			int clientNum = Game::CG_GetClientNum();
-			if (!Game::CL_IsCgameInitialized() || clientNum >= 18 || clientNum < 0 || !Game::g_entities[clientNum].client)
-			{
-				Logger::Print("You are not hosting a match!\n");
-				Toast::Show("cardicon_stop", "Error", "You are not hosting a match!", toastDurationMedium);
-				return;
-			}
-
-			if (!Dvar::Var("sv_cheats").get<bool>())
-			{
-				Logger::Print("Cheats disabled!\n");
-				Toast::Show("cardicon_stop", "Error", "Cheats disabled!", toastDurationMedium);
-				return;
-			}
-
-			if (params->length() != 4 && params->length() != 6)
-			{
-				Logger::Print("Invalid coordinate specified!\n");
-				Toast::Show("cardicon_stop", "Error", "Invalid coordinate specified!", toastDurationMedium);
-				return;
-			}
-
-			float pos[3] = { 0.0f, 0.0f, 0.0f };
-			float orientation[3] = { 0.0f, 0.0f, 0.0f };
-
-			pos[0] = strtof(params->get(1), nullptr);
-			pos[1] = strtof(params->get(2), nullptr);
-			pos[2] = strtof(params->get(3), nullptr);
-
-			if (params->length() == 6)
-			{
-				orientation[0] = strtof(params->get(4), nullptr);
-				orientation[1] = strtof(params->get(5), nullptr);
-			}
-
-			Game::TeleportPlayer(&Game::g_entities[clientNum], pos, orientation);
-
-			// Logging will spam the console and screen if people use cinematics
-		});
-
 		Command::Add("openLink", [](Command::Params* params)
 		{
 			if (params->length() > 1)


### PR DESCRIPTION
Restore setviewpos command as it should be.
This pr removes setviewpos from the command module as its implementation is wrong (only works in private match).

The new command is handled by the client-command handler and behaves like IW's implementation on other versions of the game where the function is present (The game original handler for the client-command setviewpos was removed in the version of the game IW4x uses).