### PR TITLE
Refactor startup messages

### DIFF
--- a/src/Components/Modules/StartupMessages.cpp
+++ b/src/Components/Modules/StartupMessages.cpp
@@ -23,14 +23,20 @@ namespace Components
 				StartupMessages::TotalMessages = StartupMessages::MessageList.size();
 			}
 
-			std::string message = StartupMessages::MessageList.front();
-			StartupMessages::MessageList.pop_front();
+			const auto& message = StartupMessages::MessageList.front();
 
 			Game::Dvar_SetStringByName("ui_startupMessage", message.data());
 			Game::Dvar_SetStringByName("ui_startupMessageTitle", Utils::String::VA("Messages (%d/%d)", StartupMessages::TotalMessages - StartupMessages::MessageList.size(), StartupMessages::TotalMessages));
 			Game::Dvar_SetStringByName("ui_startupNextButtonText", StartupMessages::MessageList.size() ? "Next" : "Close");
 			Game::Cbuf_AddText(0, "openmenu startup_messages");
+
+			StartupMessages::MessageList.pop_front();
 		});
+	}
+
+	StartupMessages::~StartupMessages()
+	{
+		StartupMessages::MessageList.clear();
 	}
 
 	void StartupMessages::AddMessage(const std::string& message)

--- a/src/Components/Modules/StartupMessages.hpp
+++ b/src/Components/Modules/StartupMessages.hpp
@@ -6,6 +6,7 @@ namespace Components
 	{
 	public:
 		StartupMessages();
+		~StartupMessages();
 
 		static void AddMessage(const std::string& message);
 


### PR DESCRIPTION
A quick glance at the c++ standard reveals that std::list::front returns a reference to the first element, while pop_front removes it invaliding the reference, of course.
A quick refactor allows us to avoid the unintentional copy of the string and then I also clear the list in the deconstructor of the class as it is the norm in all the other modules.