### PR TITLE
Partially revert some changes from "fix compile errors on c++20"

### DIFF
--- a/src/Components/Modules/Command.cpp
+++ b/src/Components/Modules/Command.cpp
@@ -18,14 +18,14 @@ namespace Components
 		return result;
 	}
 
-	char* Command::Params::operator[](size_t index)
+	const char* Command::Params::operator[](size_t index)
 	{
 		return this->get(index);
 	}
 
-	char* Command::ClientParams::get(size_t index)
+	const char* Command::ClientParams::get(size_t index)
 	{
-		if (index >= this->length()) return const_cast<char*>("");
+		if (index >= this->length()) return "";
 		return Game::cmd_argv[this->commandId][index];
 	}
 
@@ -34,9 +34,9 @@ namespace Components
 		return Game::cmd_argc[this->commandId];
 	}
 
-	char* Command::ServerParams::get(size_t index)
+	const char* Command::ServerParams::get(size_t index)
 	{
-		if (index >= this->length()) return const_cast<char*>("");
+		if (index >= this->length()) return "";
 		return Game::cmd_argv_sv[this->commandId][index];
 	}
 

--- a/src/Components/Modules/Command.hpp
+++ b/src/Components/Modules/Command.hpp
@@ -10,11 +10,11 @@ namespace Components
 		public:
 			Params() {};
 			virtual ~Params() {};
-			virtual char* get(size_t index) = 0;
+			virtual const char* get(size_t index) = 0;
 			virtual size_t length() = 0;
 
 			virtual std::string join(size_t startIndex);
-			virtual char* operator[](size_t index);
+			virtual const char* operator[](size_t index);
 		};
 
 		class ClientParams : public Params
@@ -24,7 +24,7 @@ namespace Components
 			ClientParams(const ClientParams &obj) : commandId(obj.commandId) {};
 			ClientParams() : ClientParams(*Game::cmd_id) {};
 
-			char* get(size_t index) override;
+			const char* get(size_t index) override;
 			size_t length() override;
 
 		private:
@@ -38,7 +38,7 @@ namespace Components
 			ServerParams(const ServerParams &obj) : commandId(obj.commandId) {};
 			ServerParams() : ServerParams(*Game::cmd_id_sv) {};
 
-			char* get(size_t index) override;
+			const char* get(size_t index) override;
 			size_t length() override;
 
 		private:

--- a/src/Components/Modules/Dvar.cpp
+++ b/src/Components/Modules/Dvar.cpp
@@ -21,19 +21,19 @@ namespace Components
 		return this->dvar;
 	}
 
-	template <> char* Dvar::Var::get()
-	{
-		if (this->dvar && this->dvar->type == Game::dvar_type::DVAR_TYPE_STRING && this->dvar->current.string)
-		{
-			return const_cast<char*>(this->dvar->current.string);
-		}
-
-		return const_cast<char*>("");
-	}
-
 	template <> const char* Dvar::Var::get()
 	{
-		return this->get<char*>();
+		if (this->dvar == nullptr)
+			return "";
+
+		if (this->dvar->type == Game::dvar_type::DVAR_TYPE_STRING
+			|| this->dvar->type == Game::dvar_type::DVAR_TYPE_ENUM)
+		{
+			if (this->dvar->current.string != nullptr)
+				return this->dvar->current.string;
+		}
+
+		return "";
 	}
 
 	template <> int Dvar::Var::get()
@@ -198,7 +198,7 @@ namespace Components
 		Scheduler::OnFrame([]()
 		{
 			static std::string lastValidName = "Unknown Soldier";
-			std::string name = Dvar::Var("name").get<char*>();
+			std::string name = Dvar::Var("name").get<const char*>();
 
 			// Don't perform any checks if name didn't change
 			if (name == lastValidName) return;

--- a/src/Components/Modules/Friends.cpp
+++ b/src/Components/Modules/Friends.cpp
@@ -186,7 +186,7 @@ namespace Components
 		{
 			std::lock_guard<std::recursive_mutex> _(Friends::Mutex);
 
-			const unsigned int modId = *reinterpret_cast<unsigned int*>(const_cast<char*>("IW4x")) | 0x80000000;
+			const unsigned int modId = *reinterpret_cast<unsigned int*>("IW4x") | 0x80000000;
 
 			// Split up the list
 			for (auto entry : Friends::FriendsList)

--- a/src/Components/Modules/Playlist.cpp
+++ b/src/Components/Modules/Playlist.cpp
@@ -21,7 +21,7 @@ namespace Components
 
 		Dvar::Var("xblive_privateserver").set(false);
 
-		std::string playlistFilename = Dvar::Var("playlistFilename").get<char*>();
+		std::string playlistFilename = Dvar::Var("playlistFilename").get<const char*>();
 		FileSystem::File playlist(playlistFilename);
 
 		if (playlist.exists())

--- a/src/Components/Modules/UIScript.cpp
+++ b/src/Components/Modules/UIScript.cpp
@@ -15,19 +15,14 @@ namespace Components
 		return 0;
 	}
 
-	template<> char* UIScript::Token::get()
+	template<> const char* UIScript::Token::get()
 	{
 		if (this->isValid())
 		{
 			return this->token;
 		}
 
-		return const_cast<char*>("");
-	}
-
-	template<> const char* UIScript::Token::get()
-	{
-		return this->get<char*>();
+		return "";
 	}
 
 	template<> std::string UIScript::Token::get()

--- a/src/Components/Modules/ZoneBuilder.cpp
+++ b/src/Components/Modules/ZoneBuilder.cpp
@@ -1300,7 +1300,7 @@ namespace Components
 				}, nullptr, false);
 
 				// HACK: set language to 'techsets' to load from that dir
-				char* language = Utils::Hook::Get<char*>(0x649E740);
+				const char* language = Utils::Hook::Get<const char*>(0x649E740);
 				Utils::Hook::Set<const char*>(0x649E740, "techsets");
 
 				// load generated techset fastfiles
@@ -1447,7 +1447,7 @@ namespace Components
 				Utils::IO::WriteFile("zone_source/techsets/techsets.csv", csvStr.data());
 
 				// set language back
-				Utils::Hook::Set<char*>(0x649E740, language);
+				Utils::Hook::Set<const char*>(0x649E740, language);
 
 				Logger::Print("Building zone 'techsets/techsets'...\n");
 				Zone("techsets/techsets").build();

--- a/src/Game/Functions.cpp
+++ b/src/Game/Functions.cpp
@@ -773,9 +773,9 @@ namespace Game
 
 	float Vec2Normalize(vec2_t& vec)
 	{
-		const float length = std::sqrt((vec[0] * vec[0]) + (vec[1] * vec[1]));
+		const auto length = std::sqrt(vec[0] * vec[0] + vec[1] * vec[1]);
 
-		if(length > 0.0f)
+		if (length > 0.0f)
 		{
 			vec[0] /= length;
 			vec[1] /= length;
@@ -786,9 +786,9 @@ namespace Game
 
 	float Vec3Normalize(vec3_t& vec)
 	{
-		const float length = std::sqrt(std::pow(vec[0], 2.0f) + std::pow(vec[1], 2.0f) + std::pow(vec[2], 2.0f));
+		const auto length = std::sqrt(vec[0] * vec[0] + vec[1] * vec[1] + vec[2] * vec[2]);
 
-		if(length > 0.0f)
+		if (length > 0.0f)
 		{
 			vec[0] /= length;
 			vec[1] /= length;


### PR DESCRIPTION
Let's use const char*
🥶 🍦

Removed template char* getter function from a bunch of modules as it can't be a good idea to convert a `const char*` string (for example `this->dvar->current.string`) to a `char*` like you wouldn't want to accidentally modify those strings.

PS
`std::pow(vec[0], 2.0f)` is slow while `vec[0] * vec[0]` is faster. It is also what the game's Vec3Normalize function does.