### PR TITLE
Fix gamepad vars

### DIFF
--- a/src/Components/Modules/Dvar.cpp
+++ b/src/Components/Modules/Dvar.cpp
@@ -5,10 +5,10 @@ namespace Components
 	Utils::Signal<Scheduler::Callback> Dvar::RegistrationSignal;
 	const char* Dvar::ArchiveDvarPath = "userraw/archivedvars.cfg";
 
-	Dvar::Var::Var(const std::string& dvarName) : Var()
+	Dvar::Var::Var(const std::string& _dvarName) : Var()
 	{
-		this->dvar = Game::Dvar_FindVar(dvarName.data());
-		this->dvarName = dvarName;
+		this->dvar = Game::Dvar_FindVar(_dvarName.data());
+		this->dvarName = _dvarName;
 	}
 
 	void Dvar::Var::registerDvar()

--- a/src/Components/Modules/Dvar.cpp
+++ b/src/Components/Modules/Dvar.cpp
@@ -5,42 +5,27 @@ namespace Components
 	Utils::Signal<Scheduler::Callback> Dvar::RegistrationSignal;
 	const char* Dvar::ArchiveDvarPath = "userraw/archivedvars.cfg";
 
-	Dvar::Var::Var(const std::string& _dvarName) : Var()
+	Dvar::Var::Var(const std::string& dvarName) : Var()
 	{
-		this->dvar = Game::Dvar_FindVar(_dvarName.data());
-		this->dvarName = _dvarName;
-	}
-
-	void Dvar::Var::registerDvar()
-	{
-		assert(!this->dvarName.empty() && this->dvar == nullptr);
-
-		auto* var = Game::Dvar_FindVar(this->dvarName.data());
+		this->dvar = Game::Dvar_FindVar(dvarName.data());
 
 		// If the dvar can't be found it will be registered as an empty string dvar
-		if (var == nullptr)
+		if (this->dvar == nullptr)
 		{
-			this->dvar = const_cast<Game::dvar_t*>(Game::Dvar_SetFromStringByNameFromSource(this->dvarName.data(), "",
+			this->dvar = const_cast<Game::dvar_t*>(Game::Dvar_SetFromStringByNameFromSource(dvarName.data(), "",
 				Game::DvarSetSource::DVAR_SOURCE_INTERNAL));
-		}	
-		else
-		{
-			this->dvar = var;
 		}
 	}
 
 	template <> Game::dvar_t* Dvar::Var::get()
 	{
-		if (this->dvar == nullptr)
-			this->registerDvar();
-
 		return this->dvar;
 	}
 
 	template <> const char* Dvar::Var::get()
 	{
 		if (this->dvar == nullptr)
-			this->registerDvar();
+			return "";
 
 		if (this->dvar->type == Game::dvar_type::DVAR_TYPE_STRING
 			|| this->dvar->type == Game::dvar_type::DVAR_TYPE_ENUM)
@@ -55,7 +40,7 @@ namespace Components
 	template <> int Dvar::Var::get()
 	{
 		if (this->dvar == nullptr)
-			this->registerDvar();
+			return 0;
 
 		if (this->dvar->type == Game::dvar_type::DVAR_TYPE_INT || this->dvar->type == Game::dvar_type::DVAR_TYPE_ENUM)
 		{
@@ -68,20 +53,20 @@ namespace Components
 	template <> unsigned int Dvar::Var::get()
 	{
 		if (this->dvar == nullptr)
-			this->registerDvar();
+			return 0u;
 
 		if (this->dvar->type == Game::dvar_type::DVAR_TYPE_INT)
 		{
 			return this->dvar->current.unsignedInt;
 		}
 
-		return 0;
+		return 0u;
 	}
 
 	template <> float Dvar::Var::get()
 	{
 		if (this->dvar == nullptr)
-			this->registerDvar();
+			return 0.f;
 
 		if (this->dvar->type == Game::dvar_type::DVAR_TYPE_FLOAT)
 		{
@@ -96,7 +81,7 @@ namespace Components
 		static Game::vec4_t vector{ 0.f, 0.f, 0.f, 0.f };
 
 		if (this->dvar == nullptr)
-			this->registerDvar();
+			return vector;
 
 		if (this->dvar && (this->dvar->type == Game::dvar_type::DVAR_TYPE_FLOAT_2 || this->dvar->type == Game::dvar_type::DVAR_TYPE_FLOAT_3 || this->dvar->type == Game::dvar_type::DVAR_TYPE_FLOAT_4))
 		{
@@ -109,7 +94,7 @@ namespace Components
 	template <> bool Dvar::Var::get()
 	{
 		if (this->dvar == nullptr)
-			this->registerDvar();
+			return false;
 
 		if (this->dvar->type == Game::dvar_type::DVAR_TYPE_BOOL)
 		{

--- a/src/Components/Modules/Dvar.cpp
+++ b/src/Components/Modules/Dvar.cpp
@@ -15,17 +15,17 @@ namespace Components
 	{
 		assert(!this->dvarName.empty() && this->dvar == nullptr);
 
-		auto* dvar = Game::Dvar_FindVar(this->dvarName.data());
+		auto* var = Game::Dvar_FindVar(this->dvarName.data());
 
 		// If the dvar can't be found it will be registered as an empty string dvar
-		if (dvar == nullptr)
+		if (var == nullptr)
 		{
 			this->dvar = const_cast<Game::dvar_t*>(Game::Dvar_SetFromStringByNameFromSource(this->dvarName.data(), "",
 				Game::DvarSetSource::DVAR_SOURCE_INTERNAL));
 		}	
 		else
 		{
-			this->dvar = dvar;
+			this->dvar = var;
 		}
 	}
 

--- a/src/Components/Modules/Dvar.cpp
+++ b/src/Components/Modules/Dvar.cpp
@@ -83,7 +83,8 @@ namespace Components
 		if (this->dvar == nullptr)
 			return vector;
 
-		if (this->dvar && (this->dvar->type == Game::dvar_type::DVAR_TYPE_FLOAT_2 || this->dvar->type == Game::dvar_type::DVAR_TYPE_FLOAT_3 || this->dvar->type == Game::dvar_type::DVAR_TYPE_FLOAT_4))
+		if (this->dvar->type == Game::dvar_type::DVAR_TYPE_FLOAT_2 || this->dvar->type == Game::dvar_type::DVAR_TYPE_FLOAT_3
+			|| this->dvar->type == Game::dvar_type::DVAR_TYPE_FLOAT_4)
 		{
 			return this->dvar->current.vector;
 		}
@@ -280,7 +281,7 @@ namespace Components
 			}
 		}
 
-		return Dvar::SetFromStringByNameExternal(dvarName, string);
+		Dvar::SetFromStringByNameExternal(dvarName, string);
 	}
 
 	void Dvar::SetFromStringByNameExternal(const char* dvarName, const char* string)

--- a/src/Components/Modules/Dvar.hpp
+++ b/src/Components/Modules/Dvar.hpp
@@ -18,14 +18,14 @@ namespace Components
 		{
 		public:
 			Var() : dvar(nullptr) {};
-			Var(const Var &obj) { this->dvar = obj.dvar; };
-			Var(Game::dvar_t* _dvar) : dvar(_dvar) {};
+			Var(const Var& obj) { this->dvar = obj.dvar; this->dvarName = obj.dvarName; };
+			Var(Game::dvar_t* _dvar) : dvar(_dvar), dvarName(_dvar->name) {};
 			Var(DWORD ppdvar) : Var(*reinterpret_cast<Game::dvar_t**>(ppdvar)) {};
 			Var(const std::string& dvarName);
 
+			void registerDvar();
 			template<typename T> T get();
 
-			void set(char* string);
 			void set(const char* string);
 			void set(const std::string& string);
 
@@ -38,6 +38,7 @@ namespace Components
 			void setRaw(bool enabled);
 
 		private:
+			std::string dvarName;
 			Game::dvar_t* dvar;
 		};
 
@@ -58,8 +59,8 @@ namespace Components
 
 		static Game::dvar_t* RegisterName(const char* name, const char* defaultVal, Game::dvar_flag flag, const char* description);
 
-		static Game::dvar_t* SetFromStringByNameExternal(const char* dvar, const char* value);
-		static Game::dvar_t* SetFromStringByNameSafeExternal(const char* dvar, const char* value);
+		static void SetFromStringByNameExternal(const char* dvar, const char* value);
+		static void SetFromStringByNameSafeExternal(const char* dvar, const char* value);
 
 		static void SaveArchiveDvar(const Game::dvar_t* var);
 		static void DvarSetFromStringByNameStub(const char* dvarName, const char* value);

--- a/src/Components/Modules/Dvar.hpp
+++ b/src/Components/Modules/Dvar.hpp
@@ -18,12 +18,11 @@ namespace Components
 		{
 		public:
 			Var() : dvar(nullptr) {};
-			Var(const Var& obj) { this->dvar = obj.dvar; this->dvarName = obj.dvarName; };
-			Var(Game::dvar_t* _dvar) : dvar(_dvar), dvarName(_dvar->name) {};
+			Var(const Var& obj) { this->dvar = obj.dvar; };
+			Var(Game::dvar_t* _dvar) : dvar(_dvar) {};
 			Var(DWORD ppdvar) : Var(*reinterpret_cast<Game::dvar_t**>(ppdvar)) {};
 			Var(const std::string& dvarName);
 
-			void registerDvar();
 			template<typename T> T get();
 
 			void set(const char* string);
@@ -38,7 +37,6 @@ namespace Components
 			void setRaw(bool enabled);
 
 		private:
-			std::string dvarName;
 			Game::dvar_t* dvar;
 		};
 

--- a/src/Components/Modules/Gamepad.cpp
+++ b/src/Components/Modules/Gamepad.cpp
@@ -1731,7 +1731,7 @@ namespace Components
         gpad_button_deadzone = Dvar::Register<float>("gpad_button_deadzone", 0.13f, 0.0f, 1.0f, Game::DVAR_FLAG_NONE, "Game pad button deadzone threshhold");
         gpad_button_lstick_deflect_max = Dvar::Register<float>("gpad_button_lstick_deflect_max", 1.0f, 0.0f, 1.0f, Game::DVAR_FLAG_NONE, "Game pad maximum pad stick pressed value");
         gpad_button_rstick_deflect_max = Dvar::Register<float>("gpad_button_rstick_deflect_max", 1.0f, 0.0f, 1.0f, Game::DVAR_FLAG_NONE, "Game pad maximum pad stick pressed value");
-        gpad_use_hold_time = Dvar::Register<int>("gpad_use_hold_time", 250, 0, INT32_MAX, Game::DVAR_FLAG_NONE, "Time to hold the 'use' button on gamepads to activate use");
+        gpad_use_hold_time = Dvar::Register<int>("gpad_use_hold_time", 250, 0, std::numeric_limits<int>::max(), Game::DVAR_FLAG_NONE, "Time to hold the 'use' button on gamepads to activate use");
         gpad_lockon_enabled = Dvar::Register<bool>("gpad_lockon_enabled", true, Game::DVAR_FLAG_SAVED, "Game pad lockon aim assist enabled");
         gpad_slowdown_enabled = Dvar::Register<bool>("gpad_slowdown_enabled", true, Game::DVAR_FLAG_SAVED, "Game pad slowdown aim assist enabled");
 
@@ -1762,10 +1762,10 @@ namespace Components
         aim_lockon_strength = Dvar::Var("aim_lockon_strength");
     }
 
-    void Gamepad::IN_Init_Hk()
+    void Gamepad::CG_RegisterDvars_Hk()
     {
         // Call original method
-        Utils::Hook::Call<void()>(0x45D620)();
+        Utils::Hook::Call<void()>(0x4F8DC0)();
 
         InitDvars();
     }
@@ -1908,7 +1908,7 @@ namespace Components
             return;
 
         // Initialize gamepad environment
-        Utils::Hook(0x467C03, IN_Init_Hk, HOOK_CALL).install()->quick();
+        Utils::Hook(0x4059FE, CG_RegisterDvars_Hk, HOOK_CALL).install()->quick();
 
         // package the forward and right move components in the move buttons
         Utils::Hook(0x60E38D, MSG_WriteDeltaUsercmdKeyStub, HOOK_JUMP).install()->quick();

--- a/src/Components/Modules/Gamepad.hpp
+++ b/src/Components/Modules/Gamepad.hpp
@@ -187,7 +187,7 @@ namespace Components
         static void Scores_Toggle_f(Command::Params* params);
 
         static void InitDvars();
-        static void IN_Init_Hk();
+        static void CG_RegisterDvars_Hk();
 
         static const char* GetGamePadCommand(const char* command);
         static int Key_GetCommandAssignmentInternal_Hk(const char* cmd, int(*keys)[2]);

--- a/src/Game/Functions.hpp
+++ b/src/Game/Functions.hpp
@@ -256,10 +256,10 @@ namespace Game
 	typedef dvar_t* (__cdecl * Dvar_RegisterColor_t)(const char* name, float r, float g, float b, float a, int flags, const char* description);
 	extern Dvar_RegisterColor_t Dvar_RegisterColor;
 
-	typedef dvar_t* (__cdecl * Dvar_SetFromStringByName_t)(const char* cvar, const char* value);
+	typedef void(__cdecl * Dvar_SetFromStringByName_t)(const char* dvarName, const char* string);
 	extern Dvar_SetFromStringByName_t Dvar_SetFromStringByName;
 
-	typedef dvar_t* (__cdecl * Dvar_SetFromStringByNameFromSource_t)(const char* cvar, const char* value, DvarSetSource source);
+	typedef const dvar_t* (__cdecl * Dvar_SetFromStringByNameFromSource_t)(const char* dvarName, const char* string, DvarSetSource source);
 	extern Dvar_SetFromStringByNameFromSource_t Dvar_SetFromStringByNameFromSource;
 
 	typedef void (__cdecl * Dvar_SetStringByName_t)(const char* cvar, const char* value);
@@ -286,7 +286,7 @@ namespace Game
 	typedef char* (__cdecl* Dvar_InfoString_Big_t)(int typeMask);
 	extern Dvar_InfoString_Big_t Dvar_InfoString_Big;
 
-	typedef dvar_t* (__cdecl * Dvar_SetCommand_t)(const char* name, const char* value);
+	typedef void(__cdecl * Dvar_SetCommand_t)(const char* dvarName, const char* string);
 	extern Dvar_SetCommand_t Dvar_SetCommand;
 
 	typedef const char* (__cdecl * Dvar_DisplayableValue_t)(const dvar_t* cvar);

--- a/src/Game/Functions.hpp
+++ b/src/Game/Functions.hpp
@@ -265,16 +265,16 @@ namespace Game
 	typedef void (__cdecl * Dvar_SetStringByName_t)(const char* cvar, const char* value);
 	extern Dvar_SetStringByName_t Dvar_SetStringByName;
 
-	typedef void (__cdecl * Dvar_SetString_t)(dvar_t* cvar, const char* value);
+	typedef void (__cdecl * Dvar_SetString_t)(const dvar_t* cvar, const char* value);
 	extern Dvar_SetString_t Dvar_SetString;
 
-	typedef void (__cdecl * Dvar_SetBool_t)(dvar_t* cvar, bool enabled);
+	typedef void (__cdecl * Dvar_SetBool_t)(const dvar_t* cvar, bool enabled);
 	extern Dvar_SetBool_t Dvar_SetBool;
 
-	typedef void (__cdecl * Dvar_SetFloat_t)(dvar_t* cvar, float value);
+	typedef void (__cdecl * Dvar_SetFloat_t)(const dvar_t* cvar, float value);
 	extern Dvar_SetFloat_t Dvar_SetFloat;
 
-	typedef void (__cdecl * Dvar_SetInt_t)(dvar_t* cvar, int integer);
+	typedef void (__cdecl * Dvar_SetInt_t)(const dvar_t* cvar, int integer);
 	extern Dvar_SetInt_t Dvar_SetInt;
 
 	typedef void(__cdecl * Dvar_GetUnpackedColorByName_t)(const char* name, float* color);


### PR DESCRIPTION
Petition to replace
`aim_turnrate_pitch_ads = Dvar::Var("aim_turnrate_pitch_ads");`
with
`aim_turnrate_pitch_ads = Dvar::Var(0x0);` <- replace with the actual address of where the pointer is stored