### PR TITLE
[DRAFT] Moved essential code to run a single game into a separate component t…

### DIFF
--- a/src/Components/Loader.cpp
+++ b/src/Components/Loader.cpp
@@ -29,6 +29,8 @@ namespace Components
 		Loader::Uninitializing = false;
 		Utils::Memory::GetAllocator()->clear();
 
+		Loader::Register(new Scheduler());
+		Loader::Register(new Core());
 		Loader::Register(new Flags());
 		Loader::Register(new Singleton());
 		Loader::Register(new Exception()); // install our exception handler as early as posssible to get better debug dumps from startup crashes
@@ -77,7 +79,6 @@ namespace Components
 		Loader::Register(new FrameTime());
 		Loader::Register(new Gametypes());
 		Loader::Register(new Materials());
-		Loader::Register(new Scheduler());
 		Loader::Register(new Threading());
 		Loader::Register(new CardTitles());
 		Loader::Register(new FileSystem());

--- a/src/Components/Loader.hpp
+++ b/src/Components/Loader.hpp
@@ -44,7 +44,7 @@ namespace Components
 		{
 			for (auto& component : Loader::Components)
 			{
-				if (typeid(*component) == typeid(T))
+				if (std::is_same<T, decltype(component)>::value)
 				{
 					return reinterpret_cast<T*>(component);
 				}

--- a/src/Components/Loader.hpp
+++ b/src/Components/Loader.hpp
@@ -65,6 +65,7 @@ namespace Components
 #include "Modules/Auth.hpp"
 #include "Modules/Bans.hpp"
 #include "Modules/Bots.hpp"
+#include "Modules/Core.hpp"
 #include "Modules/Dvar.hpp"
 #include "Modules/Lean.hpp"
 #include "Modules/Maps.hpp"

--- a/src/Components/Modules/Auth.cpp
+++ b/src/Components/Modules/Auth.cpp
@@ -438,13 +438,6 @@ namespace Components
 		Utils::Hook(0x6265F9, Auth::DirectConnectStub, HOOK_JUMP).install()->quick();
 		Utils::Hook(0x41D3E3, Auth::SendConnectDataStub, HOOK_CALL).install()->quick();
 
-		// SteamIDs can only contain 31 bits of actual 'id' data.
-		// The other 33 bits are steam internal data like universe and so on.
-		// Using only 31 bits for fingerprints is pretty insecure.
-		// The function below verifies the integrity steam's part of the SteamID.
-		// Patching that check allows us to use 64 bit for fingerprints.
-		Utils::Hook::Set<DWORD>(0x4D0D60, 0xC301B0);
-
 		// Guid command
 		Command::Add("guid", [](Command::Params*)
 		{

--- a/src/Components/Modules/Core.cpp
+++ b/src/Components/Modules/Core.cpp
@@ -1,0 +1,98 @@
+#include <STDInclude.hpp>
+
+namespace Components
+{
+	int Core::weaponsLoaded = 0;
+	Game::XAssetEntry* Core::lastWeaponEntry = nullptr;
+	std::unordered_set<std::string> Core::skippedWeapons{};
+
+	Core::Core()
+	{
+		// SteamIDs can only contain 31 bits of actual 'id' data.
+		// The other 33 bits are steam internal data like universe and so on.
+		// Using only 31 bits for fingerprints is pretty insecure.
+		// The function below verifies the integrity steam's part of the SteamID.
+		// Patching that check allows us to use 64 bit for fingerprints.
+		// 
+		// This also prevents WIN_NO_STEAM
+		Utils::Hook::Set<DWORD>(0x4D0D60, 0xC301B0);
+
+		// remove system pre-init stuff (improper quit, disk full)
+		Utils::Hook::Set<BYTE>(0x411350, 0xC3);
+
+		// remove STEAMSTART checking for DRM IPC
+		Utils::Hook::Nop(0x451145, 5);
+		Utils::Hook::Set<BYTE>(0x45114C, 0xEB);
+
+		// disable playlist.ff loading function
+		Utils::Hook::Set<BYTE>(0x4D6E60, 0xC3);
+
+		// Override "Couldn't load image X" to never happen, because we have CODO assets that cannot be loaded without other more advanced components
+		// Doing on the fly IWI conversion is not a job for Core component, so we just nop the error for now.
+		Utils::Hook::Set<BYTE>(0x51F59F, 0xEB);
+
+		// Asset limits - instead of erroring when going above, just ignore further loads
+		Utils::Hook(0x4A473C, Core::AddXAssetIfWeaponUnderLimit, HOOK_CALL).install()->quick(); 
+
+		/////////////
+		/// various changes to SV_DirectConnect-y stuff to allow non-party joinees
+
+		// Bypass Session_FindRegisteredUser check
+		Utils::Hook::Set<WORD>(0x460D96, 0x90E9);
+
+		// Bypass invitation check
+		Utils::Hook::Set<BYTE>(0x460F0A, 0xEB);
+
+		// EXE_TRANSMITERROR
+		Utils::Hook::Set<BYTE>(0x401CA4, 0xEB);
+
+		// Bypass "user already registered"  (EXE_TRANSMITERROR)
+		Utils::Hook::Set<BYTE>(0x401C15, 0xEB);
+
+		Utils::Hook(0x5BADFF, Sys_TempPriorityEnd, HOOK_CALL).install()->quick();
+
+		// Necessary hook when Weapons component is not loaded, to avoid loading weapons over the limit and crashing
+		Utils::Hook(0x4D4A85, G_GetWeaponIndexForName, HOOK_CALL).install()->quick();
+
+		// Make sure preDestroy is called when the game shuts down
+		Scheduler::OnShutdown(Loader::PreDestroy);
+	}
+
+	Game::XAssetEntry* __cdecl Core::AddXAssetIfWeaponUnderLimit(Game::XAssetType type, Game::XAssetHeader* a2) {
+		const unsigned long DEFAULT_WEAPON_LIMIT = 1200 /* *reinterpret_cast<unsigned long*>(0x403783) */;
+
+		if (Loader::GetInstance<Weapon>() == nullptr && weaponsLoaded >= DEFAULT_WEAPON_LIMIT)
+		{
+			Components::Logger::Print("Skipped loading of weapon %s (hit limit of %d weapons)\n", a2->weapon->szInternalName, DEFAULT_WEAPON_LIMIT);
+			skippedWeapons.emplace(std::string(a2->weapon->szInternalName));
+			return lastWeaponEntry;
+		}
+		else 
+		{
+			weaponsLoaded++;
+
+			Components::Logger::Print("Loaded weapon %s (%d/%d)\n", a2->weapon->szInternalName, weaponsLoaded, DEFAULT_WEAPON_LIMIT);
+
+			lastWeaponEntry = Game::DB_AddXAsset(type, a2);
+			return lastWeaponEntry;
+		}
+	}
+
+	BOOL __cdecl Sys_TempPriorityEnd(int a1) {
+		return Utils::Hook::Call<BOOL(int)>(0x4DCF00)(a1);
+	}
+
+	unsigned int __cdecl Core::G_GetWeaponIndexForName(const char* a1)
+	{
+		if (Loader::GetInstance<Weapon>() == nullptr)
+		{
+			if (skippedWeapons.find(std::string(a1)) != skippedWeapons.end()) {
+				Components::Logger::Print("Bypassing index for weapon: %s\n", a1);
+				return 0;
+			}
+		}
+
+		return Game::G_GetWeaponIndexForName(a1);
+	}
+
+}

--- a/src/Components/Modules/Core.cpp
+++ b/src/Components/Modules/Core.cpp
@@ -53,10 +53,16 @@ namespace Components
 		Scheduler::OnShutdown(Loader::PreDestroy);
 	}
 
-	Game::XAssetEntry* __cdecl Core::AddUniqueWeaponXAsset(Game::XAssetType type, Game::XAssetHeader* asset) {
-		if (Loader::GetInstance<Weapon>() == nullptr && asset && asset->weapon) {
+	Game::XAssetEntry* __cdecl Core::AddUniqueWeaponXAsset(Game::XAssetType type, Game::XAssetHeader* asset) 
+	{
+
+		// If weapon component is present, it will take care of this
+		if (Loader::GetInstance<Weapon>() == nullptr && asset && asset->weapon) 
+		{
 			std::string name = std::string(asset->weapon->szInternalName);
-			if (loadedWeapons.find(name) != loadedWeapons.end()) {
+
+			if (loadedWeapons.find(name) != loadedWeapons.end()) 
+			{
 				auto weapon = Game::DB_FindXAssetEntry(type, name.c_str());
 
 				if (weapon == nullptr)
@@ -75,6 +81,7 @@ namespace Components
 				loadedWeapons.emplace(std::string(asset->weapon->szInternalName));
 			}
 		}
+
 		// Default behaviour, fall through
 		return Game::DB_AddXAsset(type, asset);
 	}

--- a/src/Components/Modules/Core.cpp
+++ b/src/Components/Modules/Core.cpp
@@ -31,7 +31,7 @@ namespace Components
 		// Doing on the fly IWI conversion is not a job for Core component, so we just nop the error for now.
 		Utils::Hook::Set<BYTE>(0x51F59F, 0xEB);
 
-		// Asset limits - instead of erroring when going above, just ignore further loads
+		// Asset limits for weapons - iw4x files contains duplicate for weapons, we make sure to only load them once
 		Utils::Hook(0x4A473C, Core::AddUniqueWeaponXAsset, HOOK_CALL).install()->quick(); 
 
 		/////////////
@@ -48,8 +48,6 @@ namespace Components
 
 		// Bypass "user already registered"  (EXE_TRANSMITERROR)
 		Utils::Hook::Set<BYTE>(0x401C15, 0xEB);
-
-		Utils::Hook(0x5BADFF, Sys_TempPriorityEnd, HOOK_CALL).install()->quick();
 
 		// Make sure preDestroy is called when the game shuts down
 		Scheduler::OnShutdown(Loader::PreDestroy);

--- a/src/Components/Modules/Core.cpp
+++ b/src/Components/Modules/Core.cpp
@@ -93,7 +93,6 @@ namespace Components
 			else
 			{
 				loadedWeapons.emplace(name);
-				Components::Logger::Print("Loaded weapon %s\n", name.c_str());
 			}
 		}
 

--- a/src/Components/Modules/Core.cpp
+++ b/src/Components/Modules/Core.cpp
@@ -67,14 +67,12 @@ namespace Components
 				}
 				else
 				{
-					Components::Logger::Print("Skipped loading of weapon %s (already loaded)\n", asset->weapon->szInternalName);
 					return weapon;
 				}
 			}
 			else
 			{
 				loadedWeapons.emplace(std::string(asset->weapon->szInternalName));
-				Components::Logger::Print("Loading weapon %s\n", asset->weapon->szInternalName);
 			}
 		}
 		// Default behaviour, fall through

--- a/src/Components/Modules/Core.cpp
+++ b/src/Components/Modules/Core.cpp
@@ -83,7 +83,7 @@ namespace Components
 			}
 			else
 			{
-				loadedWeapons.emplace(std::string(asset->weapon->szInternalName));
+				loadedWeapons.emplace(name);
 			}
 		}
 

--- a/src/Components/Modules/Core.cpp
+++ b/src/Components/Modules/Core.cpp
@@ -2,7 +2,8 @@
 
 namespace Components
 {
-	const unsigned long DEFAULT_WEAPON_LIMIT = *reinterpret_cast<unsigned long*>(0x403783);
+	// Vanilla basegame supports up to 1200 weapons
+	constexpr long DEFAULT_WEAPON_LIMIT = 1200;
 
 	std::unordered_set<std::string> Core::loadedWeapons{};
 
@@ -53,13 +54,17 @@ namespace Components
 		Scheduler::OnShutdown(Loader::PreDestroy);
 	}
 
-	Game::XAssetEntry* __cdecl Core::AddUniqueWeaponXAsset(Game::XAssetType type, Game::XAssetHeader* asset) 
+	Game::XAssetEntry* Core::AddUniqueWeaponXAsset(Game::XAssetType type, Game::XAssetHeader* asset) 
 	{
 
 		// If weapon component is present, it will take care of this
-		if (Loader::GetInstance<Weapon>() == nullptr && asset && asset->weapon) 
+		if (Loader::GetInstance<Weapon>() == nullptr &&
+			asset != nullptr && 
+			asset->weapon != nullptr &&
+			asset->weapon->szInternalName != nullptr
+			) 
 		{
-			std::string name = std::string(asset->weapon->szInternalName);
+			const std::string name(asset->weapon->szInternalName);
 
 			if (loadedWeapons.find(name) != loadedWeapons.end()) 
 			{

--- a/src/Components/Modules/Core.hpp
+++ b/src/Components/Modules/Core.hpp
@@ -8,7 +8,7 @@ namespace Components
 		Core();
 
 	private:
-		static Game::XAssetEntry* __cdecl AddUniqueWeaponXAsset(Game::XAssetType type, Game::XAssetHeader* a2);
+		static Game::XAssetEntry* AddUniqueWeaponXAsset(Game::XAssetType type, Game::XAssetHeader* header);
 		static std::unordered_set<std::string> loadedWeapons;
 	};
 }

--- a/src/Components/Modules/Core.hpp
+++ b/src/Components/Modules/Core.hpp
@@ -8,14 +8,7 @@ namespace Components
 		Core();
 
 	private:
-		static Game::XAssetEntry* __cdecl AddXAssetIfWeaponUnderLimit(Game::XAssetType type, Game::XAssetHeader* a2);
-
-		static int weaponsLoaded;
-		static Game::XAssetEntry* lastWeaponEntry;
-		static std::unordered_set<std::string> skippedWeapons;
-		
-		static unsigned int __cdecl G_GetWeaponIndexForName(const char* a1);
+		static Game::XAssetEntry* __cdecl AddUniqueWeaponXAsset(Game::XAssetType type, Game::XAssetHeader* a2);
+		static std::unordered_set<std::string> loadedWeapons;
 	};
-
-	static BOOL __cdecl Sys_TempPriorityEnd(int a1);
 }

--- a/src/Components/Modules/Core.hpp
+++ b/src/Components/Modules/Core.hpp
@@ -1,0 +1,21 @@
+#pragma once
+
+namespace Components
+{
+	class Core : public Component
+	{
+	public:
+		Core();
+
+	private:
+		static Game::XAssetEntry* __cdecl AddXAssetIfWeaponUnderLimit(Game::XAssetType type, Game::XAssetHeader* a2);
+
+		static int weaponsLoaded;
+		static Game::XAssetEntry* lastWeaponEntry;
+		static std::unordered_set<std::string> skippedWeapons;
+		
+		static unsigned int __cdecl G_GetWeaponIndexForName(const char* a1);
+	};
+
+	static BOOL __cdecl Sys_TempPriorityEnd(int a1);
+}

--- a/src/Components/Modules/Party.cpp
+++ b/src/Components/Modules/Party.cpp
@@ -153,12 +153,6 @@ namespace Components
 		static Game::dvar_t* partyEnable = Dvar::Register<bool>("party_enable", Dedicated::IsEnabled(), Game::dvar_flag::DVAR_NONE, "Enable party system").get<Game::dvar_t*>();
 		Dvar::Register<bool>("xblive_privatematch", true, Game::dvar_flag::DVAR_WRITEPROTECTED, "");
 
-		// various changes to SV_DirectConnect-y stuff to allow non-party joinees
-		Utils::Hook::Set<WORD>(0x460D96, 0x90E9);
-		Utils::Hook::Set<BYTE>(0x460F0A, 0xEB);
-		Utils::Hook::Set<BYTE>(0x401CA4, 0xEB);
-		Utils::Hook::Set<BYTE>(0x401C15, 0xEB);
-
 		// disable configstring checksum matching (it's unreliable at most)
 		Utils::Hook::Set<BYTE>(0x4A75A7, 0xEB); // SV_SpawnServer
 		Utils::Hook::Set<BYTE>(0x5AC2CF, 0xEB); // CL_ParseGamestate

--- a/src/Components/Modules/Playlist.cpp
+++ b/src/Components/Modules/Playlist.cpp
@@ -181,9 +181,6 @@ namespace Components
 		{
 			// Custom playlist loading
 			Utils::Hook(0x420B5A, Playlist::LoadPlaylist, HOOK_JUMP).install()->quick();
-
-			// disable playlist.ff loading function
-			Utils::Hook::Set<BYTE>(0x4D6E60, 0xC3);
 		}
 
 		Network::Handle("getPlaylist", PlaylistRequest);

--- a/src/Components/Modules/QuickPatch.cpp
+++ b/src/Components/Modules/QuickPatch.cpp
@@ -388,8 +388,6 @@ namespace Components
 		Utils::Hook(0x51B13B, QuickPatch::Dvar_RegisterAspectRatioDvar, HOOK_CALL).install()->quick();
 		Utils::Hook(0x5063F3, QuickPatch::SetAspectRatioStub, HOOK_JUMP).install()->quick();
 
-		// Make sure preDestroy is called when the game shuts down
-		Scheduler::OnShutdown(Loader::PreDestroy);
 
 		// protocol version (workaround for hacks)
 		Utils::Hook::Set<int>(0x4FB501, PROTOCOL);

--- a/src/Components/Modules/QuickPatch.cpp
+++ b/src/Components/Modules/QuickPatch.cpp
@@ -546,11 +546,6 @@ namespace Components
 		// allow joining 'developer 1' servers
 		Utils::Hook::Set<BYTE>(0x478BA2, 0xEB);
 
-		// fs_game fixes
-		Utils::Hook::Nop(0x4A5D74, 2); // remove fs_game profiles
-		Utils::Hook::Set<BYTE>(0x4081FD, 0xEB); // defaultweapon
-		Utils::Hook::Set<BYTE>(0x452C1D, 0xEB); // LoadObj weaponDefs
-
 		// filesystem init default_mp.cfg check
 		Utils::Hook::Nop(0x461A9E, 5);
 		Utils::Hook::Nop(0x461AAA, 5);

--- a/src/Game/Functions.cpp
+++ b/src/Game/Functions.cpp
@@ -91,6 +91,7 @@ namespace Game
 	DB_EnumXAssets_t DB_EnumXAssets = DB_EnumXAssets_t(0x4B76D0);
 	DB_EnumXAssets_Internal_t DB_EnumXAssets_Internal = DB_EnumXAssets_Internal_t(0x5BB0A0);
 	DB_FindXAssetHeader_t DB_FindXAssetHeader = DB_FindXAssetHeader_t(0x407930);
+	DB_AddXAsset_t DB_AddXAsset = DB_AddXAsset_t(0x5BB650);
 	DB_GetRawBuffer_t DB_GetRawBuffer = DB_GetRawBuffer_t(0x4CDC50);
 	DB_GetRawFileLen_t DB_GetRawFileLen = DB_GetRawFileLen_t(0x4DAA80);
 	DB_GetLoadedFraction_t DB_GetLoadedFraction = DB_GetLoadedFraction_t(0x468380);

--- a/src/Game/Functions.hpp
+++ b/src/Game/Functions.hpp
@@ -199,6 +199,9 @@ namespace Game
 	typedef XAssetHeader (__cdecl * DB_FindXAssetHeader_t)(XAssetType type, const char* name);
 	extern DB_FindXAssetHeader_t DB_FindXAssetHeader;
 
+	typedef XAssetEntry* (__cdecl* DB_AddXAsset_t)(XAssetType type, Game::XAssetHeader* a2);
+	extern DB_AddXAsset_t DB_AddXAsset;
+
 	typedef float(__cdecl * DB_GetLoadedFraction_t)();
 	extern DB_GetLoadedFraction_t DB_GetLoadedFraction;
 


### PR DESCRIPTION
…o allow for a minimal start

the weapon bit is kind of extra but iw4x files contain weapons in duplicate, so making sure they're only loaded once (unless the weapons component is loaded) is necessary for running proper.

The target we want the minimal component to be able to achieve is : Launch the game, get (alone) into a multiplayer map, play for as long as you would need to, with the smallest possible amount of modifications (no modifications that are not strictly necessary to run a vanilla map).

This restructuration's goal is to make possible to disable/enable components at will to facilitate debugging and still allow to run a vanilla map from the basegame with everything disabled 🙂