### PR TITLE
Logger improvements

### DIFF
--- a/src/Components/Modules/FileSystem.cpp
+++ b/src/Components/Modules/FileSystem.cpp
@@ -28,7 +28,7 @@ namespace Components
 		if (!rawfile || Game::DB_IsXAssetDefault(Game::XAssetType::ASSET_TYPE_RAWFILE, this->filePath.data())) return;
 
 		this->buffer.resize(Game::DB_GetRawFileLen(rawfile));
-		Game::DB_GetRawBuffer(rawfile, const_cast<char*>(this->buffer.data()), this->buffer.size());
+		Game::DB_GetRawBuffer(rawfile, this->buffer.data(), static_cast<int>(this->buffer.size()));
 	}
 
 	FileSystem::FileReader::FileReader(const std::string& file) : handle(0), name(file)

--- a/src/Game/Functions.hpp
+++ b/src/Game/Functions.hpp
@@ -329,7 +329,7 @@ namespace Game
 	typedef int(__cdecl * FS_FOpenFileReadForThread_t)(const char *filename, int *file, int thread);
 	extern FS_FOpenFileReadForThread_t FS_FOpenFileReadForThread;
 
-	typedef int(__cdecl * FS_FCloseFile_t)(int fh);
+	typedef int(__cdecl * FS_FCloseFile_t)(int stream);
 	extern FS_FCloseFile_t FS_FCloseFile;
 
 	typedef bool(__cdecl * FS_FileExists_t)(const char* file);


### PR DESCRIPTION
The game functions that our logger hooks will not ever use a buffer larger than 4096 bytes.
Also, IW4x does not seem to need such a large buffer (on the heap). 4096 is plenty, and faster because now it's on the stack.