### PR TITLE
Use master server, fallback to node if not reached

### DIFF
--- a/src/Components/Modules/Dedicated.cpp
+++ b/src/Components/Modules/Dedicated.cpp
@@ -374,7 +374,6 @@ namespace Components
 					}
 				});
 
-#ifdef USE_LEGACY_SERVER_LIST
 				// Heartbeats
 				Scheduler::Once(Dedicated::Heartbeat);
 				Scheduler::OnFrame([]()
@@ -387,7 +386,6 @@ namespace Components
 						Dedicated::Heartbeat();
 					}
 				});
-#endif
 
 				Dvar::OnInit([]()
 				{

--- a/src/Components/Modules/Node.cpp
+++ b/src/Components/Modules/Node.cpp
@@ -114,6 +114,7 @@ namespace Components
 
 	void Node::StoreNodes(bool force)
 	{
+		if (ServerList::useMasterServer) return;
 		if (Dedicated::IsEnabled() && Dvar::Var("sv_lanOnly").get<bool>()) return;
 
 		static Utils::Time::Interval interval;
@@ -167,6 +168,7 @@ namespace Components
 
 	void Node::RunFrame()
 	{
+		if (ServerList::useMasterServer) return;
 		if (Dedicated::IsEnabled() && Dvar::Var("sv_lanOnly").get<bool>()) return;
 
 		if (!Dedicated::IsEnabled() && *Game::clcState > 0)

--- a/src/Components/Modules/Node.cpp
+++ b/src/Components/Modules/Node.cpp
@@ -248,7 +248,7 @@ namespace Components
 
 		if (list.isnode() && (!list.port() || list.port() == address.getPort()))
 		{
-			if (!Dedicated::IsEnabled() && ServerList::IsOnlineList() && list.protocol() == PROTOCOL)
+			if (!Dedicated::IsEnabled() && ServerList::IsOnlineList() && !ServerList::useMasterServer && list.protocol() == PROTOCOL)
 			{
 				NODE_LOG("Inserting %s into the serverlist\n", address.getCString());
 				ServerList::InsertRequest(address);

--- a/src/Components/Modules/Node.cpp
+++ b/src/Components/Modules/Node.cpp
@@ -114,7 +114,6 @@ namespace Components
 
 	void Node::StoreNodes(bool force)
 	{
-		if (ServerList::useMasterServer) return;
 		if (Dedicated::IsEnabled() && Dvar::Var("sv_lanOnly").get<bool>()) return;
 
 		static Utils::Time::Interval interval;

--- a/src/Components/Modules/ServerList.cpp
+++ b/src/Components/Modules/ServerList.cpp
@@ -273,7 +273,7 @@ namespace Components
 			const auto masterServerName = Dvar::Var("masterServerName").get<const char*>();
 
 			Game::netadr_t masterServerAddr;
-			if (ServerList::GetMasterServer(masterServerAddr))
+			if (ServerList::GetMasterServer(masterServerName, masterPort, masterServerAddr))
 			{
 				Toast::Show("cardicon_headshot", "Server Browser", "Fetching servers...", 3000);
 				useMasterServer = true;
@@ -738,12 +738,9 @@ namespace Components
 		}
 	}
 
-	bool ServerList::GetMasterServer(Game::netadr_t& address)
+	bool ServerList::GetMasterServer(const char* ip, int port, Game::netadr_t& address)
 	{
-		auto masterPort = Dvar::Var("masterPort").get<int>();
-		auto masterServerName = Dvar::Var("masterServerName").get<const char*>();
-
-		return Game::NET_StringToAdr(Utils::String::VA("%s:%u", masterServerName, masterPort), &address);
+		return Game::NET_StringToAdr(Utils::String::VA("%s:%u", ip, port), &address);
 	}
 
 	bool ServerList::IsServerListOpen()

--- a/src/Components/Modules/ServerList.cpp
+++ b/src/Components/Modules/ServerList.cpp
@@ -272,20 +272,25 @@ namespace Components
 			const auto masterPort = Dvar::Var("masterPort").get<int>();
 			const auto masterServerName = Dvar::Var("masterServerName").get<const char*>();
 
+			// Check if our dvars can properly convert to a address
 			Game::netadr_t masterServerAddr;
-			if (ServerList::GetMasterServer(masterServerName, masterPort, masterServerAddr))
+			if (!ServerList::GetMasterServer(masterServerName, masterPort, masterServerAddr))
 			{
-				Toast::Show("cardicon_headshot", "Server Browser", "Fetching servers...", 3000);
-				useMasterServer = true;
-
-				ServerList::RefreshContainer.awatingList = true;
-				ServerList::RefreshContainer.awaitTime = Game::Sys_Milliseconds();
-
-				ServerList::RefreshContainer.host = Network::Address(Utils::String::VA("%s:%u", masterServerName, masterPort));
-
-				Logger::Print("Sending serverlist request to master\n");
-				Network::SendCommand(ServerList::RefreshContainer.host, "getservers", Utils::String::VA("IW4 %i full empty", PROTOCOL));
+				Logger::Print("Could not resolve address for %s:%u", masterServerName, masterPort);
+				Toast::Show("cardicon_headshot", "^1Error", Utils::String::VA("Could not resolve address for %s:%u", masterServerName, masterPort), 5000);
+				return;
 			}
+
+			Toast::Show("cardicon_headshot", "Server Browser", "Fetching servers...", 3000);
+
+			useMasterServer = true;
+
+			ServerList::RefreshContainer.awatingList = true;
+			ServerList::RefreshContainer.awaitTime = Game::Sys_Milliseconds();
+			ServerList::RefreshContainer.host = Network::Address(Utils::String::VA("%s:%u", masterServerName, masterPort));
+
+			Logger::Print("Sending serverlist request to master\n");
+			Network::SendCommand(ServerList::RefreshContainer.host, "getservers", Utils::String::VA("IW4 %i full empty", PROTOCOL));
 		}
 		else if (ServerList::IsFavouriteList())
 		{

--- a/src/Components/Modules/ServerList.cpp
+++ b/src/Components/Modules/ServerList.cpp
@@ -207,13 +207,6 @@ namespace Components
 		auto list = ServerList::GetList();
 		if (!list) return;
 
-		// Refresh entirely, if there is no entry in the list
-		if (list->empty())
-		{
-			ServerList::Refresh(UIScript::Token());
-			return;
-		}
-
 		bool ui_browserShowFull     = Dvar::Var("ui_browserShowFull").get<bool>();
 		bool ui_browserShowEmpty    = Dvar::Var("ui_browserShowEmpty").get<bool>();
 		int ui_browserShowHardcore  = Dvar::Var("ui_browserKillcam").get<int>();

--- a/src/Components/Modules/ServerList.cpp
+++ b/src/Components/Modules/ServerList.cpp
@@ -275,7 +275,7 @@ namespace Components
 			Game::netadr_t masterServerAddr;
 			if (ServerList::GetMasterServer(masterServerAddr))
 			{
-				Toast::Show("cardicon_headshot", "", "Fetching servers...", 3000);
+				Toast::Show("cardicon_headshot", "Server Browser", "Fetching servers...", 3000);
 				useMasterServer = true;
 
 				ServerList::RefreshContainer.awatingList = true;

--- a/src/Components/Modules/ServerList.cpp
+++ b/src/Components/Modules/ServerList.cpp
@@ -566,7 +566,7 @@ namespace Components
 	void ServerList::SortList()
 	{
 		// Only sort when the serverlist is open
-		if (!IsServerListOpen()) return;
+		if (!ServerList::IsServerListOpen()) return;
 
 		std::stable_sort(ServerList::VisibleList.begin(), ServerList::VisibleList.end(), [](const unsigned int &server1, const unsigned int &server2) -> bool
 		{
@@ -633,7 +633,7 @@ namespace Components
 		if (ServerList::RefreshContainer.awatingList)
 		{
 			// Stop counting if we are out of the server browser menu
-			if (!IsServerListOpen())
+			if (!ServerList::IsServerListOpen())
 			{
 				ServerList::RefreshContainer.awatingList = false;
 			}
@@ -745,7 +745,7 @@ namespace Components
 
 	bool ServerList::IsServerListOpen()
 	{
-		Game::menuDef_t* menu = Game::Menus_FindByName(Game::uiContext, "pc_join_unranked");
+		auto* menu = Game::Menus_FindByName(Game::uiContext, "pc_join_unranked");
 		if (!menu) 
 			return false;
 
@@ -811,7 +811,7 @@ namespace Components
 		});
 
 		// Set default masterServerName + port and save it 
-		Utils::Hook::Set<char*>(0x60AD92, "master.xlabs.dev");
+		Utils::Hook::Set<const char*>(0x60AD92, "master.xlabs.dev");
 		Utils::Hook::Set<BYTE>(0x60AD90, Game::dvar_flag::DVAR_ARCHIVE); // masterServerName
 		Utils::Hook::Set<BYTE>(0x60ADC6, Game::dvar_flag::DVAR_ARCHIVE); // masterPort
 

--- a/src/Components/Modules/ServerList.hpp
+++ b/src/Components/Modules/ServerList.hpp
@@ -50,6 +50,9 @@ namespace Components
 
 		static void UpdateVisibleInfo();
 
+		static bool GetMasterServer(Game::netadr_t& address);
+		static bool useMasterServer;
+
 	private:
 		enum Column
 		{

--- a/src/Components/Modules/ServerList.hpp
+++ b/src/Components/Modules/ServerList.hpp
@@ -146,5 +146,7 @@ namespace Components
 		static Dvar::Var UIServerSelectedMap;
 		static Dvar::Var NETServerQueryLimit;
 		static Dvar::Var NETServerFrames;
+
+		static bool IsServerListOpen();
 	};
 }

--- a/src/Components/Modules/ServerList.hpp
+++ b/src/Components/Modules/ServerList.hpp
@@ -50,7 +50,7 @@ namespace Components
 
 		static void UpdateVisibleInfo();
 
-		static bool GetMasterServer(Game::netadr_t& address);
+		static bool GetMasterServer(const char* ip, int port, Game::netadr_t& address);
 		static bool useMasterServer;
 
 	private:


### PR DESCRIPTION
this will probably spark a discussion, but after talking to Jebus, I'm pretty sure this should happen. this uses `master.xlabs.dev:20810` as the master server already has support for IW4x and if the master server is not reached within 5 seconds, a toast will appear notifying that node is being used and will fallback to using node servers. node doesn't get used on the client until this point is reached. node is then disabled once going back into the server browser again.

im no expert at c++, so please review 