### PR TITLE
Make keybind fields in menus work with controller keys

### DIFF
--- a/src/Components/Modules/Gamepad.cpp
+++ b/src/Components/Modules/Gamepad.cpp
@@ -1846,6 +1846,14 @@ namespace Components
 		}
 	}
 
+	void Gamepad::Key_SetBinding_Hk(const int localClientNum, const int keyNum, const char* binding)
+	{
+		if(Key_IsValidGamePadChar(keyNum))
+            gpad_buttonConfig.set("custom");
+
+        Game::Key_SetBinding(localClientNum, keyNum, binding);
+	}
+
 	void Gamepad::CL_KeyEvent_Hk(const int localClientNum, const int key, const int down, const unsigned time)
 	{
 		// A keyboard key has been pressed. Mark controller as unused.
@@ -1983,6 +1991,11 @@ namespace Components
 
 		// Only return gamepad keys when gamepad enabled and only non gamepad keys when not
 		Utils::Hook(0x5A7890, Key_GetCommandAssignmentInternal_Stub, HOOK_JUMP).install()->quick();
+
+		// Whenever a key binding for a gamepad key is replaced update the button config
+		Utils::Hook(0x47D473, Key_SetBinding_Hk, HOOK_CALL).install()->quick();
+		Utils::Hook(0x47D485, Key_SetBinding_Hk, HOOK_CALL).install()->quick();
+		Utils::Hook(0x47D49D, Key_SetBinding_Hk, HOOK_CALL).install()->quick();
 
 		// Add gamepad inputs to remote control (eg predator) handling
 		Utils::Hook(0x5A6D4E, CL_RemoteControlMove_Stub, HOOK_CALL).install()->quick();

--- a/src/Components/Modules/Gamepad.cpp
+++ b/src/Components/Modules/Gamepad.cpp
@@ -1849,9 +1849,9 @@ namespace Components
 	void Gamepad::Key_SetBinding_Hk(const int localClientNum, const int keyNum, const char* binding)
 	{
 		if(Key_IsValidGamePadChar(keyNum))
-            gpad_buttonConfig.set("custom");
+			gpad_buttonConfig.set("custom");
 
-        Game::Key_SetBinding(localClientNum, keyNum, binding);
+		Game::Key_SetBinding(localClientNum, keyNum, binding);
 	}
 
 	void Gamepad::CL_KeyEvent_Hk(const int localClientNum, const int key, const int down, const unsigned time)

--- a/src/Components/Modules/Gamepad.hpp
+++ b/src/Components/Modules/Gamepad.hpp
@@ -194,6 +194,7 @@ namespace Components
 		static const char* GetGamePadCommand(const char* command);
 		static int Key_GetCommandAssignmentInternal(int localClientNum, const char* cmd, int (*keys)[2]);
         static void Key_GetCommandAssignmentInternal_Stub();
+        static void Key_SetBinding_Hk(int localClientNum, int keyNum, const char* binding);
         static bool IsGamePadInUse();
 		static void CL_KeyEvent_Hk(int localClientNum, int key, int down, unsigned int time);
 		static int CL_MouseEvent_Hk(int x, int y, int dx, int dy);

--- a/src/Components/Modules/Gamepad.hpp
+++ b/src/Components/Modules/Gamepad.hpp
@@ -193,9 +193,9 @@ namespace Components
 
 		static const char* GetGamePadCommand(const char* command);
 		static int Key_GetCommandAssignmentInternal(int localClientNum, const char* cmd, int (*keys)[2]);
-        static void Key_GetCommandAssignmentInternal_Stub();
-        static void Key_SetBinding_Hk(int localClientNum, int keyNum, const char* binding);
-        static bool IsGamePadInUse();
+		static void Key_GetCommandAssignmentInternal_Stub();
+		static void Key_SetBinding_Hk(int localClientNum, int keyNum, const char* binding);
+		static bool IsGamePadInUse();
 		static void CL_KeyEvent_Hk(int localClientNum, int key, int down, unsigned int time);
 		static int CL_MouseEvent_Hk(int x, int y, int dx, int dy);
 		static bool UI_RefreshViewport_Hk();

--- a/src/Components/Modules/Gamepad.hpp
+++ b/src/Components/Modules/Gamepad.hpp
@@ -192,8 +192,9 @@ namespace Components
 		static void CG_RegisterDvars_Hk();
 
 		static const char* GetGamePadCommand(const char* command);
-		static int Key_GetCommandAssignmentInternal_Hk(const char* cmd, int(*keys)[2]);
-		static bool IsGamePadInUse();
+		static int Key_GetCommandAssignmentInternal(int localClientNum, const char* cmd, int (*keys)[2]);
+        static void Key_GetCommandAssignmentInternal_Stub();
+        static bool IsGamePadInUse();
 		static void CL_KeyEvent_Hk(int localClientNum, int key, int down, unsigned int time);
 		static int CL_MouseEvent_Hk(int x, int y, int dx, int dy);
 		static bool UI_RefreshViewport_Hk();

--- a/src/Game/Functions.cpp
+++ b/src/Game/Functions.cpp
@@ -171,6 +171,7 @@ namespace Game
 	Key_SetCatcher_t Key_SetCatcher = Key_SetCatcher_t(0x43BD00);
 	Key_RemoveCatcher_t Key_RemoveCatcher = Key_RemoveCatcher_t(0x408260);
 	Key_IsKeyCatcherActive_t Key_IsKeyCatcherActive = Key_IsKeyCatcherActive_t(0x4DA010);
+	Key_SetBinding_t Key_SetBinding = Key_SetBinding_t(0x494C90);
 
 	LargeLocalInit_t LargeLocalInit = LargeLocalInit_t(0x4A62A0);
 

--- a/src/Game/Functions.cpp
+++ b/src/Game/Functions.cpp
@@ -558,6 +558,8 @@ namespace Game
 	int* window_center_x = reinterpret_cast<int*>(0x649D638);
 	int* window_center_y = reinterpret_cast<int*>(0x649D630);
 
+	int* g_waitingForKey = reinterpret_cast<int*>(0x63A50FC);
+
 	void Sys_LockRead(FastCriticalSection* critSect)
 	{
 		InterlockedIncrement(&critSect->readCount);

--- a/src/Game/Functions.hpp
+++ b/src/Game/Functions.hpp
@@ -1158,6 +1158,8 @@ namespace Game
 	extern int* window_center_x;
 	extern int* window_center_y;
 
+	extern int* g_waitingForKey;
+
 	void Sys_LockRead(FastCriticalSection* critSect);
 	void Sys_UnlockRead(FastCriticalSection* critSect);
 

--- a/src/Game/Functions.hpp
+++ b/src/Game/Functions.hpp
@@ -420,6 +420,9 @@ namespace Game
 	typedef bool(__cdecl * Key_IsKeyCatcherActive_t)(int localClientNum, int catcher);
 	extern Key_IsKeyCatcherActive_t Key_IsKeyCatcherActive;
 
+	typedef void(__cdecl * Key_SetBinding_t)(int localClientNum, int keyNum, const char* binding);
+	extern Key_SetBinding_t Key_SetBinding;
+
 	typedef void(__cdecl * LargeLocalInit_t)();
 	extern LargeLocalInit_t LargeLocalInit;
 


### PR DESCRIPTION
Before keystrokes in an active bind field could not bind controller keys because the values of the remapped menu keys were taken.
Now all controller buttons can be rebound using these menu fields.
The menu fields show KBM keys whenever KBM is used and gamepad keys whenever gamepad is in use.

Additionally whenever a gamepad button is rebound using a menu field, the button config is set to custom so the gamepad options show an empty value (indicating custom values) for button layout