### PR TITLE
fix visible server list refreshing

### DIFF
--- a/src/Components/Modules/ServerList.cpp
+++ b/src/Components/Modules/ServerList.cpp
@@ -200,12 +200,23 @@ namespace Components
 
 	void ServerList::RefreshVisibleList(UIScript::Token)
 	{
+		ServerList::RefreshVisibleListInternal(UIScript::Token());
+	}
+
+	void ServerList::RefreshVisibleListInternal(UIScript::Token, bool refresh)
+	{
 		Dvar::Var("ui_serverSelected").set(false);
 
 		ServerList::VisibleList.clear();
 
 		auto list = ServerList::GetList();
 		if (!list) return;
+
+		if (refresh)
+		{
+			ServerList::Refresh(UIScript::Token());
+			return;
+		}
 
 		bool ui_browserShowFull     = Dvar::Var("ui_browserShowFull").get<bool>();
 		bool ui_browserShowEmpty    = Dvar::Var("ui_browserShowEmpty").get<bool>();
@@ -368,7 +379,7 @@ namespace Components
 		auto list = ServerList::GetList();
 		if (list) list->clear();
 		
-		ServerList::RefreshVisibleList(UIScript::Token());
+		ServerList::RefreshVisibleListInternal(UIScript::Token());
 		
 		Game::ShowMessageBox("Server removed from favourites.", "Success");
 	}
@@ -530,7 +541,7 @@ namespace Components
 					if (lList)
 					{
 						lList->push_back(server);
-						ServerList::RefreshVisibleList(UIScript::Token());
+						ServerList::RefreshVisibleListInternal(UIScript::Token());
 					}
 				}
 
@@ -693,7 +704,7 @@ namespace Components
 
 		netSource.set(source);
 
-		ServerList::RefreshVisibleList(UIScript::Token());
+		ServerList::RefreshVisibleListInternal(UIScript::Token(), true);
 	}
 
 	void ServerList::UpdateGameType()
@@ -709,7 +720,7 @@ namespace Components
 
 		joinGametype.set(gametype);
 
-		ServerList::RefreshVisibleList(UIScript::Token());
+		ServerList::RefreshVisibleListInternal(UIScript::Token());
 	}
 
 	void ServerList::UpdateVisibleInfo()

--- a/src/Components/Modules/ServerList.hpp
+++ b/src/Components/Modules/ServerList.hpp
@@ -35,6 +35,7 @@ namespace Components
 
 		static void Refresh(UIScript::Token);
 		static void RefreshVisibleList(UIScript::Token);
+		static void RefreshVisibleListInternal(UIScript::Token, bool refresh = false);
 		static void UpdateVisibleList(UIScript::Token);
 		static void InsertRequest(Network::Address address);
 		static void Insert(Network::Address address, Utils::InfoString info);


### PR DESCRIPTION
this should fix changing the source (Internet, Local, Favorites) category of the server list and having servers still in the list and visible list not properly working. this reimplements the refreshing on visible list, but it must be specified to refresh. default value for refresh is false as defined in the header.