### PR TITLE
only return node frame on non-dedi instances with master server on

### DIFF
--- a/src/Components/Modules/Node.cpp
+++ b/src/Components/Modules/Node.cpp
@@ -167,7 +167,7 @@ namespace Components
 
 	void Node::RunFrame()
 	{
-		if (ServerList::useMasterServer) return;
+		if (!Dedicated::IsEnabled() && ServerList::useMasterServer) return;
 		if (Dedicated::IsEnabled() && Dedicated::SVLanOnly.get<bool>()) return;
 
 		if (!Dedicated::IsEnabled() && *Game::clcState > 0)


### PR DESCRIPTION
i read the Dedicated::IsEnabled() check way too fast and realized that SVLanOnly is why it exists.