### PR TITLE
Fix crash on clearing keys via menus

### DIFF
--- a/src/Components/Modules/Gamepad.cpp
+++ b/src/Components/Modules/Gamepad.cpp
@@ -1787,6 +1787,9 @@ namespace Components
 	{
 		auto keyCount = 0;
 
+		(*keys)[0] = -1;
+		(*keys)[1] = -1;
+
 		if (gamePads[0].inUse)
 		{
 			const auto gamePadCmd = GetGamePadCommand(cmd);


### PR DESCRIPTION
Fixes #276

Reimplementation of key lookup didn't initialize key indices like the game does since they get used even though returned key count is 0 or 1 in case the backspace key is pressed.