### PR TITLE
[Script] (feature request): Enchance script loading

### DIFF
--- a/src/Components/Modules/Script.hpp
+++ b/src/Components/Modules/Script.hpp
@@ -8,8 +8,6 @@ namespace Components
 	public:
 		Script();
 
-		static int LoadScriptAndLabel(const std::string& script, const std::string& label);
-
 		static void AddFunction(const char* name, Game::BuiltinFunction func, int type = 0);
 		static void AddMethod(const char* name, Game::BuiltinMethod func, int type = 0);
 
@@ -19,16 +17,19 @@ namespace Components
 
 	private:
 		static std::string ScriptName;
-		static std::vector<int> ScriptHandles;
 		static std::unordered_map<std::string, Game::BuiltinFunctionDef> CustomScrFunctions;
 		static std::unordered_map<std::string, Game::BuiltinMethodDef> CustomScrMethods;
 		static std::vector<std::string> ScriptNameStack;
 		static unsigned short FunctionName;
 		static std::unordered_map<std::string, std::string> ScriptStorage;
 		static std::unordered_map<int, std::string> ScriptBaseProgramNum;
+		static int LastFrameTime;
+
+		static std::vector<int> ScriptMainHandles;
+		static std::vector<int> ScriptInitHandles;
+
 		static std::unordered_map<const char*, const char*> ReplacedFunctions;
 		static const char* ReplacedPos;
-		static int LastFrameTime;
 
 		static void CompileError(unsigned int offset, const char* message, ...);
 		static void PrintSourcePos(const char* filename, unsigned int offset);
@@ -43,8 +44,9 @@ namespace Components
 		static void RestoreScriptName();
 		static void RestoreScriptNameStub();
 
-		static void LoadGameType();
-		static void LoadGameTypeScript();
+		static void Scr_LoadGameType_Stub();
+		static void Scr_StartupGameType_Stub();
+		static void GScr_LoadGameTypeScript_Stub();
 
 		static Game::BuiltinFunction BuiltIn_GetFunctionStub(const char** pName, int* type);
 		static Game::BuiltinMethod BuiltIn_GetMethod(const char** pName, int* type);

--- a/src/Game/Functions.cpp
+++ b/src/Game/Functions.cpp
@@ -274,6 +274,7 @@ namespace Game
 	RemoveRefToObject_t RemoveRefToObject = RemoveRefToObject_t(0x437190);
 
 	Scr_LoadGameType_t Scr_LoadGameType = Scr_LoadGameType_t(0x4D9520);
+	Scr_StartupGameType_t Scr_StartupGameType = Scr_StartupGameType_t(0x438720);
 
 	Scr_LoadScript_t Scr_LoadScript = Scr_LoadScript_t(0x45D940);
 	Scr_GetFunctionHandle_t Scr_GetFunctionHandle = Scr_GetFunctionHandle_t(0x4234F0);

--- a/src/Game/Functions.hpp
+++ b/src/Game/Functions.hpp
@@ -717,8 +717,11 @@ namespace Game
 	typedef void(__cdecl * Scr_ShutdownAllocNode_t)();
 	extern Scr_ShutdownAllocNode_t Scr_ShutdownAllocNode;
 
-	typedef int(__cdecl * Scr_LoadGameType_t)();
+	typedef void(__cdecl * Scr_LoadGameType_t)();
 	extern Scr_LoadGameType_t Scr_LoadGameType;
+
+	typedef void(__cdecl * Scr_StartupGameType_t)();
+	extern Scr_StartupGameType_t Scr_StartupGameType;
 
 	typedef int(__cdecl * Scr_LoadScript_t)(const char*);
 	extern Scr_LoadScript_t Scr_LoadScript;
@@ -750,13 +753,13 @@ namespace Game
 	typedef int(__cdecl * Scr_GetFunctionHandle_t)(const char* filename, const char* name);
 	extern Scr_GetFunctionHandle_t Scr_GetFunctionHandle;
 
-	typedef int(__cdecl * Scr_ExecThread_t)(int, int);
+	typedef int(__cdecl * Scr_ExecThread_t)(int handle, unsigned int paramcount);
 	extern Scr_ExecThread_t Scr_ExecThread;
 
 	typedef int(__cdecl * Scr_ExecEntThread_t)(gentity_s* ent, int handle, unsigned int paramcount);
 	extern Scr_ExecEntThread_t Scr_ExecEntThread;
 
-	typedef int(__cdecl * Scr_FreeThread_t)(int);
+	typedef void(__cdecl * Scr_FreeThread_t)(unsigned __int16 handle);
 	extern Scr_FreeThread_t Scr_FreeThread;
 
 	typedef void(__cdecl * Scr_Notify_t)(gentity_t *ent, unsigned __int16 stringValue, unsigned int paramcount);


### PR DESCRIPTION
This enhances the loading code, currently, if a script does not have a function called 'init' or 'main' a sort of warning is printed to indicate that both are missing. This doesn't need to happen as custom scripts can have custom entry points that are not necessarily called that way. Additionally, a community member made a request some time ago to have custom scripts with both 'main' and 'init' functions load both and not just 'init'. This promotes script compatibility with other clients.