### PR TITLE
[Logger] Fix output by g_log_list & log_list

### DIFF
--- a/src/Components/Modules/Logger.cpp
+++ b/src/Components/Modules/Logger.cpp
@@ -144,12 +144,14 @@ namespace Components
 
 	void Logger::NetworkLog(const char* data, bool gLog)
 	{
-		if (!data) return;
+		if (data == nullptr)
+		{
+			return;
+		}
 
-		const std::string buffer(data);
 		for (const auto& addr : Logger::LoggingAddresses[gLog & 1])
 		{
-			Network::SendCommand(addr, "print", buffer);
+			Network::SendCommand(addr, "print", data);
 		}
 	}
 
@@ -167,12 +169,12 @@ namespace Components
 		const auto tens = Game::level->time / 1000 % 60 / 10;
 		const auto sec = Game::level->time / 1000 % 60 % 10;
 
-		_snprintf_s(string, _TRUNCATE, "%3i:%i%i %s",
+		const auto len = _snprintf_s(string, _TRUNCATE, "%3i:%i%i %s",
 			min, tens, sec, string2);
 
 		if (Game::level->logFile != nullptr)
 		{
-			Game::FS_Write(string, &string[std::strlen(string) + 1] - &string[1], reinterpret_cast<int>(Game::level->logFile));
+			Game::FS_Write(string, len, reinterpret_cast<int>(Game::level->logFile));
 		}
 
 		// Allow the network log to run even if logFile was not opened

--- a/src/Components/Modules/Logger.cpp
+++ b/src/Components/Modules/Logger.cpp
@@ -265,7 +265,7 @@ namespace Components
 		{
 			if (params->size() < 2) return;
 
-			int num = atoi(params->get(1));
+			const auto num = atoi(params->get(1));
 			if (Utils::String::VA("%i", num) == std::string(params->get(1)) && static_cast<unsigned int>(num) < Logger::LoggingAddresses[0].size())
 			{
 				auto addr = Logger::LoggingAddresses[0].begin() + num;
@@ -296,7 +296,7 @@ namespace Components
 
 			for (unsigned int i = 0; i < Logger::LoggingAddresses[0].size(); ++i)
 			{
-				Logger::Print("{}: {}\n", i, Logger::LoggingAddresses[0][i].getCString());
+				Logger::Print("#{:03d}: {}\n", i, Logger::LoggingAddresses[0][i].getCString());
 			}
 		});
 
@@ -316,7 +316,7 @@ namespace Components
 		{
 			if (params->size() < 2) return;
 
-			int num = atoi(params->get(1));
+			const auto num = std::atoi(params->get(1));
 			if (Utils::String::VA("%i", num) == std::string(params->get(1)) && static_cast<unsigned int>(num) < Logger::LoggingAddresses[1].size())
 			{
 				const auto addr = Logger::LoggingAddresses[1].begin() + num;
@@ -347,7 +347,7 @@ namespace Components
 
 			for (std::size_t i = 0; i < Logger::LoggingAddresses[1].size(); ++i)
 			{
-				Logger::Print("{}: {}\n", i, Logger::LoggingAddresses[1][i].getCString());
+				Logger::Print("#{:03d}: {}\n", i, Logger::LoggingAddresses[1][i].getCString());
 			}
 		});
 	}

--- a/src/Components/Modules/Logger.hpp
+++ b/src/Components/Modules/Logger.hpp
@@ -100,7 +100,7 @@ namespace Components
 		static void(*PipeCallback)(const std::string&);
 
 		static void Frame();
-		static void GameLogStub();
+		static void G_LogPrintfStub(const char* fmt, ...);
 		static void PrintMessageStub();
 		static void PrintMessagePipe(const char* data);
 		static void EnqueueMessage(const std::string& message);

--- a/src/Components/Modules/Theatre.cpp
+++ b/src/Components/Modules/Theatre.cpp
@@ -19,7 +19,7 @@ namespace Components
 	void Theatre::RecordGamestateStub()
 	{
 		int sequence = (*Game::serverMessageSequence - 1);
-		Game::FS_Write(&sequence, 4, *Game::demoFile);
+		Game::FS_WriteToDemo(&sequence, 4, *Game::demoFile);
 	}
 
 	void Theatre::StoreBaseline(PBYTE snapshotMsg)
@@ -62,10 +62,10 @@ namespace Components
 		int byte8 = 8;
 		char byte0 = 0;
 
-		Game::FS_Write(&byte0, 1, *Game::demoFile);
-		Game::FS_Write(Game::serverMessageSequence, 4, *Game::demoFile);
-		Game::FS_Write(&fileCompressedSize, 4, *Game::demoFile);
-		Game::FS_Write(&byte8, 4, *Game::demoFile);
+		Game::FS_WriteToDemo(&byte0, 1, *Game::demoFile);
+		Game::FS_WriteToDemo(Game::serverMessageSequence, 4, *Game::demoFile);
+		Game::FS_WriteToDemo(&fileCompressedSize, 4, *Game::demoFile);
+		Game::FS_WriteToDemo(&byte8, 4, *Game::demoFile);
 
 		for (int i = 0; i < compressedSize; i += 1024)
 		{
@@ -77,7 +77,7 @@ namespace Components
 				break;
 			}
 
-			Game::FS_Write(&cmpData[i], size, *Game::demoFile);
+			Game::FS_WriteToDemo(&cmpData[i], size, *Game::demoFile);
 		}
 	}
 

--- a/src/Game/Functions.cpp
+++ b/src/Game/Functions.cpp
@@ -148,7 +148,8 @@ namespace Game
 	FS_FOpenFileReadForThread_t FS_FOpenFileReadForThread = FS_FOpenFileReadForThread_t(0x643270);
 	FS_FCloseFile_t FS_FCloseFile = FS_FCloseFile_t(0x462000);
 	FS_WriteFile_t FS_WriteFile = FS_WriteFile_t(0x426450);
-	FS_Write_t FS_Write = FS_Write_t(0x4C06E0);
+	FS_WriteToDemo_t  FS_WriteToDemo = FS_WriteToDemo_t(0x4C06E0);
+	FS_Write_t FS_Write = FS_Write_t(0x4576C0);
 	FS_Printf_t FS_Printf = FS_Printf_t(0x459320);
 	FS_Read_t FS_Read = FS_Read_t(0x4A04C0);
 	FS_Seek_t FS_Seek = FS_Seek_t(0x4A63D0);

--- a/src/Game/Functions.hpp
+++ b/src/Game/Functions.hpp
@@ -365,10 +365,13 @@ namespace Game
 	typedef bool(__cdecl * FS_FileExists_t)(const char* file);
 	extern FS_FileExists_t FS_FileExists;
 
-	typedef bool(__cdecl * FS_WriteFile_t)(char* filename, char* folder, void* buffer, int size);
+	typedef bool(__cdecl * FS_WriteFile_t)(const char* filename, const char* folder, const void* buffer, int size);
 	extern FS_WriteFile_t FS_WriteFile;
 
-	typedef int(__cdecl * FS_Write_t)(const void* buffer, size_t size, int file);
+	typedef int(__cdecl * FS_WriteToDemo_t)(const void* buffer, int size, int file);
+	extern FS_WriteToDemo_t FS_WriteToDemo;
+
+	typedef int(__cdecl * FS_Write_t)(const void* buffer, int len, int h);
 	extern FS_Write_t FS_Write;
 
 	typedef int(__cdecl * FS_Printf_t)(int file, const char* fmt, ...);


### PR DESCRIPTION
Thanks to Raidmax, another bug was found and squashed.
This makes the output of logger::print match what it was pre-c++20 (std::format) logger.
Also allows people to receive network logs even if the logfile was not opened