### PR TITLE
Disable additional zones for vanilla maps

### DIFF
--- a/src/Components/Modules/Maps.cpp
+++ b/src/Components/Modules/Maps.cpp
@@ -130,38 +130,30 @@ namespace Components
 
 		Maps::SPMap = false;
 		Maps::CurrentMainZone = zoneInfo->name;
-		
 		Maps::CurrentDependencies.clear();
-		for (auto i = Maps::DependencyList.begin(); i != Maps::DependencyList.end(); ++i)
-		{
-			if (std::regex_match(zoneInfo->name, std::regex(i->first)))
-			{
-				if (std::find(Maps::CurrentDependencies.begin(), Maps::CurrentDependencies.end(), i->second) == Maps::CurrentDependencies.end())
-				{
-					Maps::CurrentDependencies.push_back(i->second);
-				}
-			}
-		}
 
-		Utils::Memory::Allocator allocator;
-		auto teams = Maps::GetTeamsForMap(Maps::CurrentMainZone);
-
-		auto dependencies = Maps::GetDependenciesForMap(Maps::CurrentMainZone);
-		Utils::Merge(&Maps::CurrentDependencies, dependencies.data(), dependencies.size());
-
+		auto dependencies = GetDependenciesForMap(zoneInfo->name);
+		
 		std::vector<Game::XZoneInfo> data;
 		Utils::Merge(&data, zoneInfo, zoneCount);
+		Utils::Memory::Allocator allocator;
 		
-		Game::XZoneInfo team;
-		team.allocFlags = zoneInfo->allocFlags;
-		team.freeFlags = zoneInfo->freeFlags;
+		if (dependencies.requiresTeamZones)
+		{
+			auto teams = dependencies.requiredTeams;
 
-		team.name = allocator.duplicateString(Utils::String::VA("iw4x_team_%s", teams.first.data()));
-		data.push_back(team);
+			Game::XZoneInfo team;
+			team.allocFlags = zoneInfo->allocFlags;
+			team.freeFlags = zoneInfo->freeFlags;
 
-		team.name = allocator.duplicateString(Utils::String::VA("iw4x_team_%s", teams.second.data()));
-		data.push_back(team);
+			team.name = allocator.duplicateString(Utils::String::VA("iw4x_team_%s", teams.first.data()));
+			data.push_back(team);
 
+			team.name = allocator.duplicateString(Utils::String::VA("iw4x_team_%s", teams.second.data()));
+			data.push_back(team);
+		}
+
+		Utils::Merge(&Maps::CurrentDependencies, dependencies.requiredMaps.data(), dependencies.requiredMaps.size());
 		for (unsigned int i = 0; i < Maps::CurrentDependencies.size(); ++i)
 		{
 			Game::XZoneInfo info;
@@ -336,66 +328,42 @@ namespace Components
 		Maps::SPMap = true;
 	}
 
-	void Maps::AddDependency(const std::string& expression, const std::string& zone)
-	{
-		// Test expression before adding it
-		try
-		{
-			std::regex _(expression);
-		}
-		catch (const std::regex_error ex)
-		{
-			MessageBoxA(nullptr, Utils::String::VA("Invalid regular expression: %s", expression.data()), "Warning", MB_ICONEXCLAMATION);
-			return;
-		}
-
-		Maps::DependencyList.push_back({expression, zone});
-	}
-
 	int Maps::IgnoreEntityStub(const char* entity)
 	{
 		return (Utils::String::StartsWith(entity, "dyn_") || Utils::String::StartsWith(entity, "node_") || Utils::String::StartsWith(entity, "actor_"));
 	}
 
-	std::vector<std::string> Maps::GetDependenciesForMap(const std::string& map)
+	Maps::MapDependencies Maps::GetDependenciesForMap(const std::string& map)
 	{
-		for (int i = 0; i < *Game::arenaCount; ++i)
-		{
-			Game::newMapArena_t* arena = &ArenaLength::NewArenas[i];
-			if (arena->mapName == map)
-			{
-				for (int j = 0; j < ARRAYSIZE(arena->keys); ++j)
-				{
-					if (arena->keys[j] == "dependency"s)
-					{
-						return Utils::String::Split(arena->values[j], ' ');
-					}
-				}
-			}
-		}
+		std::string teamAxis = "opforce_composite";
+		std::string teamAllies = "us_army";
 
-		return {};
-	}
-
-	std::pair<std::string, std::string> Maps::GetTeamsForMap(const std::string& map)
-	{
-		std::string team_axis = "opforce_composite";
-		std::string team_allies = "us_army";
+		Maps::MapDependencies dependencies{};
 
 		for (int i = 0; i < *Game::arenaCount; ++i)
 		{
 			Game::newMapArena_t* arena = &ArenaLength::NewArenas[i];
 			if (arena->mapName == map)
 			{
-				for (int j = 0; j < ARRAYSIZE(arena->keys); ++j)
+				for (std::size_t j = 0; j < std::extent_v<decltype(Game::newMapArena_t::keys)>; ++j)
 				{
-					if (arena->keys[j] == "allieschar"s)
+					const auto* key = arena->keys[j];
+					const auto* value = arena->values[j];
+					if (key == "dependency"s)
 					{
-						team_allies = arena->values[j];
+						dependencies.requiredMaps = Utils::String::Split(arena->values[j], ' ');
 					}
-					else if (arena->keys[j] == "axischar"s)
+					else if (key == "allieschar"s)
 					{
-						team_axis = arena->values[j];
+						teamAllies = value;
+					}
+					else if (key == "axischar"s)
+					{
+						teamAxis = value;
+					}
+					else if (key == "useteamzones"s)
+					{
+						dependencies.requiresTeamZones = Utils::String::ToLower(value) == "true"s;
 					}
 				}
 
@@ -403,7 +371,9 @@ namespace Components
 			}
 		}
 
-		return {team_axis, team_allies};
+		dependencies.requiredTeams = std::make_pair(teamAllies, teamAxis);
+
+		return dependencies;
 	}
 
 	void Maps::PrepareUsermap(const char* mapname)
@@ -904,13 +874,6 @@ namespace Components
 
 		// Load usermap arena file
 		Utils::Hook(0x630A88, Maps::LoadArenaFileStub, HOOK_CALL).install()->quick();
-
-		// Dependencies
-		//Maps::AddDependency("oilrig", "mp_subbase");
-		//Maps::AddDependency("gulag", "mp_subbase");
-		//Maps::AddDependency("invasion", "mp_rust");
-		//Maps::AddDependency("co_hunted", "mp_storm");
-		//Maps::AddDependency("mp_shipment", "mp_shipment_long");
 
 		// Allow hiding specific smodels
 		Utils::Hook(0x50E67C, Maps::HideModelStub, HOOK_CALL).install()->quick();

--- a/src/Components/Modules/Maps.hpp
+++ b/src/Components/Modules/Maps.hpp
@@ -50,10 +50,6 @@ namespace Components
 		~Maps();
 
 		static void HandleAsSPMap();
-		static void AddDependency(const std::string& expression, const std::string& zone);
-
-		static std::pair<std::string, std::string> GetTeamsForMap(const std::string& map);
-		static std::vector<std::string> GetDependenciesForMap(const std::string& map);
 
 		static std::string CurrentMainZone;
 		static const char* UserMapFiles[4];
@@ -76,6 +72,13 @@ namespace Components
 			std::vector<std::string> maps;
 		};
 
+		struct MapDependencies
+		{
+			std::vector<std::string> requiredMaps;
+			std::pair<std::string, std::string> requiredTeams;
+			bool requiresTeamZones;
+		};
+
 		static bool SPMap;
 		static UserMapContainer UserMap;
 		static std::vector<DLC> DlcPacks;
@@ -91,6 +94,7 @@ namespace Components
 		static void UnloadMapZones(Game::XZoneInfo *zoneInfo, unsigned int zoneCount, int sync);
 
 		static void OverrideMapEnts(Game::MapEnts* ents);
+		static MapDependencies GetDependenciesForMap(const std::string& map);
 
 		static int IgnoreEntityStub(const char* entity);
 


### PR DESCRIPTION
Vanilla maps don't need team FF, so let the arena specify if it's needed or not and if not let's not load additional zones for nothing.
This improves loading time by quite a bit i've heard.

Tested on iw3 and iw4 maps with success, but this still needs a bit more testing