### PR TITLE
Fix crash snow

### DIFF
--- a/src/Components/Modules/AssetInterfaces/IMaterial.cpp
+++ b/src/Components/Modules/AssetInterfaces/IMaterial.cpp
@@ -44,6 +44,7 @@ namespace Assets
 			{"wc_unlit_alphatest", "wc_unlit_blend_lin"},
 			{"wc_unlit_blend", "wc_unlit_blend_lin_ua"},
 			{"wc_unlit_replace", "wc_unlit_replace_lin"},
+			{"wc_unlit_nofog", "wc_unlit_replace_lin_nofog_nocast" },
 
 			{"mc_unlit_replace", "mc_unlit_replace_lin"},
 			{"mc_unlit_nofog", "mc_unlit_blend_nofog_ua"},

--- a/src/Components/Modules/ZoneBuilder.cpp
+++ b/src/Components/Modules/ZoneBuilder.cpp
@@ -1527,7 +1527,8 @@ namespace Components
 				Logger::Print("------------------- END IWI DUMP -------------------\n");
 			});
 
-			ZoneBuilder::PreferDiskAssetsDvar = Dvar::Register<bool>("zb_prefer_disk_assets", false, Game::DVAR_NONE, "Should zonebuilder prefer in-memory assets (requirements) or disk assets, when both are present?");
+			// True by default, but can be put to zero for backward compatibility if needed
+			ZoneBuilder::PreferDiskAssetsDvar = Dvar::Register<bool>("zb_prefer_disk_assets", true, Game::DVAR_NONE, "Should zonebuilder prefer in-memory assets (requirements) or disk assets, when both are present?");
 		}
 	}
 


### PR DESCRIPTION
Just an addition to the techswap table + use zb assets by default cause not doing so is nonsense & causing problems too often. We keep the option to use in-memory assets though for backward compatibility