### PR TITLE
[Script] Strtol & Float

### DIFF
--- a/src/Components/Modules/GSC/ScriptExtension.cpp
+++ b/src/Components/Modules/GSC/ScriptExtension.cpp
@@ -175,16 +175,16 @@ namespace Components
 		// Func present on IW5
 		Script::AddFunction("IsEndStr", [] // gsc: IsEndStr(<string>, <string>)
 		{
-			const auto* s1 = Game::Scr_GetString(0);
-			const auto* s2 = Game::Scr_GetString(1);
+			const auto* str = Game::Scr_GetString(0);
+			const auto* suffix = Game::Scr_GetString(1);
 
-			if (s1 == nullptr || s2 == nullptr)
+			if (str == nullptr || suffix == nullptr)
 			{
 				Game::Scr_Error("^1IsEndStr: Illegal parameters!\n");
 				return;
 			}
 
-			Game::Scr_AddBool(Utils::String::EndsWith(s1, s2));
+			Game::Scr_AddBool(Utils::String::EndsWith(str, suffix));
 		});
 
 		Script::AddFunction("IsArray", [] // gsc: IsArray(<object>)
@@ -205,6 +205,41 @@ namespace Components
 			}
 
 			Game::Scr_AddBool(result);
+		});
+
+		// Func present on IW5
+		Script::AddFunction("Float", [] // gsc: Float()
+		{
+			switch (Game::Scr_GetType(0))
+			{
+			case Game::VAR_STRING:
+				Game::Scr_AddFloat(static_cast<float>(std::atof(Game::Scr_GetString(0))));
+				break;
+			case Game::VAR_FLOAT:
+				Game::Scr_AddFloat(Game::Scr_GetFloat(0));
+				break;
+			case Game::VAR_INTEGER:
+				Game::Scr_AddFloat(static_cast<float>(Game::Scr_GetInt(0)));
+				break;
+			default:
+				Game::Scr_ParamError(0, Utils::String::VA("cannot cast %s to float", Game::Scr_GetTypeName(0)));
+				break;
+			}
+		});
+
+		Script::AddFunction("Strtol", [] // gsc: Strtol(<string>, <int>)
+		{
+			const auto* input = Game::Scr_GetString(0);
+			const auto base = Game::Scr_GetInt(1);
+
+			char* end;
+			const auto result = std::strtol(input, &end, base);
+			if (input == end)
+			{
+				Game::Scr_ParamError(0, "cannot cast string to int");
+			}
+
+			Game::Scr_AddInt(result);
 		});
 	}
 

--- a/src/Game/Functions.cpp
+++ b/src/Game/Functions.cpp
@@ -300,6 +300,7 @@ namespace Game
 	Scr_GetFloat_t Scr_GetFloat = Scr_GetFloat_t(0x443140);
 	Scr_GetInt_t Scr_GetInt = Scr_GetInt_t(0x4F31D0);
 	Scr_GetObject_t Scr_GetObject = Scr_GetObject_t(0x462100);
+	Scr_GetTypeName_t Scr_GetTypeName = Scr_GetTypeName_t(0x4EFF10);
 	Scr_GetNumParam_t Scr_GetNumParam = Scr_GetNumParam_t(0x4B0E90);
 	Scr_GetEntityId_t Scr_GetEntityId = Scr_GetEntityId_t(0x4165E0);
 
@@ -478,6 +479,8 @@ namespace Game
 	Z_VirtualAlloc_t Z_VirtualAlloc = Z_VirtualAlloc_t(0x4CFBA0);
 
 	I_strncpyz_t I_strncpyz = I_strncpyz_t(0x4D6F80);
+
+	XNAddrToString_t XNAddrToString = XNAddrToString_t(0x452690);
 
 	XAssetHeader* DB_XAssetPool = reinterpret_cast<XAssetHeader*>(0x7998A8);
 	unsigned int* g_poolSize = reinterpret_cast<unsigned int*>(0x7995E8);

--- a/src/Game/Functions.hpp
+++ b/src/Game/Functions.hpp
@@ -786,6 +786,9 @@ namespace Game
 	typedef unsigned int(__cdecl * Scr_GetObject_t)(unsigned int index);
 	extern Scr_GetObject_t Scr_GetObject;
 
+	typedef const char*(__cdecl * Scr_GetTypeName_t)(unsigned int index);
+	extern Scr_GetTypeName_t Scr_GetTypeName;
+
 	typedef unsigned int(__cdecl * Scr_GetNumParam_t)();
 	extern Scr_GetNumParam_t Scr_GetNumParam;
 
@@ -1151,6 +1154,9 @@ namespace Game
 
 	typedef void(__cdecl * I_strncpyz_t)(char* dest, const char* src, int destsize);
 	extern I_strncpyz_t I_strncpyz;
+
+	typedef void(__cdecl * XNAddrToString_t)(const XNADDR* xnaddr, char* str);
+	extern XNAddrToString_t XNAddrToString;
 
 	constexpr std::size_t STATIC_MAX_LOCAL_CLIENTS = 1;
 	constexpr std::size_t MAX_LOCAL_CLIENTS = 1;


### PR DESCRIPTION
Adds two new builtins
The reason for float is that it is present in IW5
The reason for Strtol is that it helps gsc modders avoid workarounds when converting a hexadecimal string to an integer like this one
![unknown](https://user-images.githubusercontent.com/37080671/183313251-f0a258f6-b360-4fe5-9feb-52dc71be900a.png)
.