### PR TITLE
Ignore missing soundnames in FX

### DIFF
--- a/src/Components/Modules/AssetInterfaces/IFxEffectDef.hpp
+++ b/src/Components/Modules/AssetInterfaces/IFxEffectDef.hpp
@@ -18,7 +18,5 @@ namespace Assets
 		void loadEfx(Game::XAssetHeader* header, const std::string& name, Components::ZoneBuilder::Zone* builder);
 		void loadNative(Game::XAssetHeader* header, const std::string& name, Components::ZoneBuilder::Zone* builder);
 		void loadFromIW4OF(Game::XAssetHeader* header, const std::string& name, Components::ZoneBuilder::Zone* builder);
-
-		void loadFxElemVisuals(Game::FxElemVisuals* visuals, char elemType, Components::ZoneBuilder::Zone* builder, Utils::Stream::Reader* reader);
 	};
 }


### PR DESCRIPTION
Oddly enough some IW5 maps (especially DLC) mention sound names that they do not have in their zones, and that aren't common sounds either. As such, these sounds are not dumped by OpenIW5+IW4OF, but they're still mentioned by name in the FX effect definition.
This causes a fatal error when building maps with zonebuilder as it expects every asset to be present during marking. But the truth is assets only mentioned by name need not to be present for the map to run. In fact once ingame, there's not even a missing asset error, so I suppose the FX themselves could be leftovers.


also i removed a bunch of deadcode i know you like it